### PR TITLE
Do not start metro bundler when building native apps...

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,10 +7,10 @@
   },
   "scripts": {
     "android:expose": "./scripts/exposeAndroid.sh",
-    "android": "react-native run-android --variant devDebug --appIdSuffix dev",
+    "android": "react-native run-android --variant devDebug --appIdSuffix dev --no-packager",
     "build:content": "yarn --cwd \"../content\" build",
     "clean": "react-native-clean-project",
-    "ios": "react-native run-ios --scheme dev",
+    "ios": "react-native run-ios --scheme dev --no-packager",
     "postinstall": "if [ -x \"$(command -v pod)\" ]; then cd ios && pod install; fi",
     "start": ". ./scripts/getGitCommitShort.sh && yarn build:content && react-native start",
     "test:jest": ". ./scripts/getGitCommitShort.sh && jest",


### PR DESCRIPTION
...as it's unable to pass env variables to it