### PR TITLE
Revert "Install cocoapods before running client tests"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,6 @@ jobs:
         with:
           node-version: 16.x
 
-      - name: Use Ruby 2.6
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.6
-
-      - name: Install CocoaPods
-        run: gem install cocoapods
-
       - name: Cache Client Dependencies
         id: cache-client-node-modules
         uses: actions/cache@v2


### PR DESCRIPTION
Reverts 29ki/29k#184

This clearly didn't work and just made the checks a lot slower :P 