### PR TITLE
Show dark status bar text as default

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,12 +7,14 @@ import codePush, {CodePushOverlay} from './lib/codePush';
 import {UiLibProvider} from './lib/uiLib/hooks/useUiLib';
 import Bootstrap from './Bootstrap';
 import {ErrorBoundary} from './lib/sentry';
+import {StatusBarRegular} from './common/components/StatusBar/StatusBar';
 
 const App = () => (
   <ErrorBoundary>
     <RecoilRoot>
       <UiLibProvider>
         <Bootstrap>
+          <StatusBarRegular />
           <Navigation />
           <CodePushOverlay />
         </Bootstrap>

--- a/client/src/common/components/StatusBar/StatusBar.tsx
+++ b/client/src/common/components/StatusBar/StatusBar.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import {Platform, StatusBar} from 'react-native';
+
+export const StatusBarRegular = () => {
+  if (Platform.OS === 'android') {
+    return null;
+  }
+
+  return <StatusBar barStyle="dark-content" />;
+};
+
+// Use to get ligth status bar text on a dark background
+export const StatusBarOnDark = () => {
+  if (Platform.OS === 'android') {
+    return null;
+  }
+
+  return <StatusBar barStyle="light-content" />;
+};


### PR DESCRIPTION
On iOS with dark mode

<img src="https://user-images.githubusercontent.com/1139207/190335812-4665ce15-42cb-49af-8313-b65951912e24.png" width=300 />

On Android keeps the contrast on the status bar since the status bar is always showing

<img src="https://user-images.githubusercontent.com/1139207/190336311-b896fc40-e608-4cb1-a627-8c166cdc3483.png" width=300 />

