### PR TITLE
Remove lineHeights

### DIFF
--- a/client/src/common/components/Typography/styles.ts
+++ b/client/src/common/components/Typography/styles.ts
@@ -10,54 +10,45 @@ const textStyles = StyleSheet.create({
   H1: {
     color: COLORS.GREY,
     fontSize: 40,
-    lineHeight: 48,
     fontFamily: OrpheusProMedium,
   },
   H2: {
     color: COLORS.GREY,
     fontSize: 32,
-    lineHeight: 41,
     fontFamily: OrpheusProMedium,
   },
   H3: {
     color: COLORS.GREY,
     fontSize: 24,
-    lineHeight: 31,
     fontFamily: OrpheusProMedium,
   },
   H4: {
     color: COLORS.GREY,
     fontSize: 20,
-    lineHeight: 28,
     fontFamily: OrpheusProMedium,
   },
   H5: {
     color: COLORS.GREY,
     fontSize: 16,
-    lineHeight: 22,
     fontFamily: OrpheusProMedium,
   },
   B1: {
     color: COLORS.GREY,
     fontSize: 20,
-    lineHeight: 26,
     fontFamily: HKGroteskMedium,
   },
   B2: {
     color: COLORS.GREY,
     fontSize: 16,
-    lineHeight: 18,
     fontFamily: HKGroteskMedium,
   },
   B3: {
     color: COLORS.GREY,
     fontSize: 14,
-    lineHeight: 16,
     fontFamily: HKGroteskMedium,
   },
   ERROR_TEXT: {
     fontSize: 14,
-    lineHeight: 20,
     color: COLORS.ERROR_PINK,
   },
   HIGHLIGHT: {


### PR DESCRIPTION
Seems like code induced line height is buggy, the font seems to already define it?
After this change I see the following:

Fixed placeholder
<img src="https://user-images.githubusercontent.com/7523828/190358306-25de5c7f-455f-4fc3-8a44-5194bf4d5abe.png" width=300 />

Line height still defined by the font?
<img width="206" alt="Screenshot 2022-09-15 at 10 42 01" src="https://user-images.githubusercontent.com/7523828/190358429-d613bea3-2df3-4a25-a915-91fcdbb6abcc.png">

