### PR TITLE
Keep button alignment for all slide states

### DIFF
--- a/client/src/routes/Temple/components/ContentControls/ContentControls.tsx
+++ b/client/src/routes/Temple/components/ContentControls/ContentControls.tsx
@@ -39,6 +39,10 @@ const SlideButton = styled(IconButton)({
   paddingHorizontal: SPACINGS.TWELVE,
 });
 
+const ButtonHidden = styled(Button).attrs({disabled: true, onPress: () => {}})({
+  opacity: 0,
+});
+
 type ContentControlsProps = {
   templeId: string;
   style?: ViewStyle;
@@ -73,7 +77,7 @@ const ContentControls: React.FC<ContentControlsProps> = ({templeId, style}) => {
           {t('controls.prev')}
         </Button>
       ) : (
-        <Spacer8 />
+        <ButtonHidden>{t('controls.prev')}</ButtonHidden>
       )}
       {exercise.slide.current.type !== 'participantSpotlight' && (
         <MediaControls>
@@ -109,7 +113,7 @@ const ContentControls: React.FC<ContentControlsProps> = ({templeId, style}) => {
           {t('controls.next')}
         </Button>
       ) : (
-        <Spacer8 />
+        <ButtonHidden>{t('controls.next')}</ButtonHidden>
       )}
     </Wrapper>
   );

--- a/client/src/routes/Temple/components/ContentControls/ContentControls.tsx
+++ b/client/src/routes/Temple/components/ContentControls/ContentControls.tsx
@@ -39,7 +39,11 @@ const SlideButton = styled(IconButton)({
   paddingHorizontal: SPACINGS.TWELVE,
 });
 
-const ButtonHidden = styled(Button).attrs({disabled: true, onPress: () => {}})({
+const ButtonHidden = styled(Button).attrs({
+  LeftIcon: ChevronLeft,
+  disabled: true,
+  onPress: () => {},
+})({
   opacity: 0,
 });
 


### PR DESCRIPTION
Swap prev and next buttons to invisible disabled  button on first and last slides to keep buttons in place. 

**Before**

<img src='https://user-images.githubusercontent.com/9316860/191741950-dd04afe2-aa3b-48b5-9975-d68f30b5037e.png' width=350 />
<br />

**After**

<img src='https://user-images.githubusercontent.com/9316860/191741663-18e3383f-7361-4857-afcb-b3e8a86006c6.png' width=350 />




