### PR TITLE
Play videos in background and disable external playback (AirPlay)

### DIFF
--- a/client/src/routes/Temple/Portal.tsx
+++ b/client/src/routes/Temple/Portal.tsx
@@ -136,11 +136,14 @@ const Portal: React.FC = () => {
         }}
         repeat={!joiningTemple}
         source={{uri: introPortal.content.videoEnd?.source}}
-        poster={introPortal.content.videoEnd?.thumbnail}
-        mixWithOthers="mix"
         resizeMode="cover"
+        poster={introPortal.content.videoEnd?.thumbnail}
         posterResizeMode="cover"
+        allowsExternalPlayback={false}
+        mixWithOthers="mix"
         disableFocus
+        playInBackground
+        playWhenInactive
       />
       {!joiningTemple && (
         <VideoStyled
@@ -152,11 +155,14 @@ const Portal: React.FC = () => {
           }}
           repeat={!temple?.started}
           source={{uri: introPortal.content.videoLoop?.source}}
-          poster={introPortal.content.videoLoop?.thumbnail}
-          mixWithOthers="mix"
           resizeMode="cover"
+          poster={introPortal.content.videoLoop?.thumbnail}
           posterResizeMode="cover"
+          allowsExternalPlayback={false}
+          mixWithOthers="mix"
           disableFocus
+          playInBackground
+          playWhenInactive
         />
       )}
       <Wrapper>

--- a/client/src/routes/Temple/components/Slides/Slides/Blocks/Video.tsx
+++ b/client/src/routes/Temple/components/Slides/Slides/Blocks/Video.tsx
@@ -50,14 +50,17 @@ const Video: React.FC<VideoProps> = ({active, source, thumbnail}) => {
   return (
     <StyledVideo
       source={source}
+      resizeMode="contain"
+      posterResizeMode="contain"
       poster={thumbnail}
       ref={videoRef}
       onLoad={() => setLoaded(true)}
-      resizeMode="contain"
-      posterResizeMode="contain"
       paused={!active || !exerciseState?.playing}
+      allowsExternalPlayback={false}
       mixWithOthers="mix"
       disableFocus
+      playInBackground
+      playWhenInactive
     />
   );
 };


### PR DESCRIPTION
- [x] Continue playing videos when notifications, alerts and control center gets on top of app
- [x] Continue playing videos when app is backgrounded
- [x] Do not allow playing on external devices - e.g. Airplay