### PR TITLE
Improve local development

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -19,8 +19,9 @@ LogBox.ignoreLogs([
 ]);
 
 if (__DEV__) {
-  auth().useEmulator('http://localhost:9099');
-  firestore().useEmulator('localhost', 8080);
+  const HOSTNAME = process.env.HOSTNAME ?? 'localhost';
+  auth().useEmulator(`http://${HOSTNAME}:9099`);
+  firestore().useEmulator(HOSTNAME, 8080);
 }
 
 AppRegistry.registerComponent('twentyninek', () => App);

--- a/client/ios/Supporting/Info.plist
+++ b/client/ios/Supporting/Info.plist
@@ -32,6 +32,13 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
+			<key>lan</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
 			<key>localhost</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,7 @@
     "clean": "react-native-clean-project",
     "ios": "react-native run-ios --scheme dev --no-packager",
     "postinstall": "if [ -x \"$(command -v pod)\" ]; then cd ios && pod install; fi",
-    "start": ". ./scripts/getGitCommitShort.sh && yarn build:content && react-native start",
+    "start": ". ./scripts/getHostname.sh && . ./scripts/getGitCommitShort.sh && yarn build:content && react-native start",
     "test:jest": "jest",
     "test:lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test:ts": "tsc --noEmit",

--- a/client/scripts/getHostname.sh
+++ b/client/scripts/getHostname.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+HOSTNAME=$(hostname -f)
+echo "HOSTNAME=$HOSTNAME"
+export HOSTNAME

--- a/firebase.json
+++ b/firebase.json
@@ -12,18 +12,22 @@
   ],
   "emulators": {
     "auth": {
+      "host": "0.0.0.0",
       "port": 9099
     },
     "firestore": {
+      "host": "0.0.0.0",
       "port": 8080
     },
     "ui": {
       "enabled": true
     },
     "functions": {
+      "host": "0.0.0.0",
       "port": 5001
     },
     "hosting": {
+      "host": "0.0.0.0",
       "port": 5000
     }
   },


### PR DESCRIPTION
This improves:
* Firebase emulator listens on all network interfaces always
* No need to ever setup local ip-address in client and `firebase.json`
* Client firebase always connects to the external hostname e.g. `macbook-pro.lan`
* Use in combination with setting a host on the API endpoint `API_ENDPOINT=http://macbook-pro.lan:5001/demo-29k-cupcake/europe-west1/api`
