### PR TITLE
Make screen backbutton reachable 

### DIFF
--- a/client/src/common/components/Screen/Screen.tsx
+++ b/client/src/common/components/Screen/Screen.tsx
@@ -17,9 +17,9 @@ const TopBarWrapper = styled.View({
   zIndex: 100,
   flexDirection: 'row',
   alignItems: 'center',
-  paddingLeft: 16,
-  paddingRight: 16,
-  height: 48,
+  paddingLeft: SPACINGS.SIXTEEN,
+  paddingRight: SPACINGS.SIXTEEN,
+  height: SPACINGS.FOURTYFOUR,
   width: '100%',
   justifyContent: 'space-between',
 });
@@ -33,7 +33,7 @@ const TopBar: React.FC<{
   onPressBack?: () => void;
 }> = ({onPressBack, hasDarkBackground: isOnDarkBackground}) => (
   <>
-    <TopSafeArea />
+    <TopSafeArea minSize={SPACINGS.SIXTEEN} />
     <TopBarWrapper>
       {onPressBack && (
         <BackButton

--- a/client/src/routes/Temple/IntroPortal.tsx
+++ b/client/src/routes/Temple/IntroPortal.tsx
@@ -16,7 +16,12 @@ import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 
 import Button from '../../common/components/Buttons/Button';
 import Gutters from '../../common/components/Gutters/Gutters';
-import {BottomSafeArea, Spacer8} from '../../common/components/Spacers/Spacer';
+import {
+  BottomSafeArea,
+  Spacer16,
+  Spacer8,
+  TopSafeArea,
+} from '../../common/components/Spacers/Spacer';
 import {Body14} from '../../common/components/Typography/Body/Body';
 import {COLORS} from '../../../../shared/src/constants/colors';
 import {HKGroteskBold} from '../../common/constants/fonts';
@@ -83,7 +88,6 @@ const BackButton = styled(IconButton)({
 const TopBar = styled(Gutters)({
   justifyContent: 'space-between',
   flexDirection: 'row',
-  marginTop: SPACINGS.SIXTEEN,
 });
 
 const IntroPortal: React.FC = () => {
@@ -140,6 +144,7 @@ const IntroPortal: React.FC = () => {
 
   return (
     <Screen noTopBar>
+      {!isFacilitator && <TopSafeArea minSize={SPACINGS.SIXTEEN} />}
       {isFocused && introPortal.videoLoop?.audio && (
         <AudioFader
           source={introPortal.videoLoop.audio}
@@ -174,7 +179,12 @@ const IntroPortal: React.FC = () => {
         />
       )}
 
-      {isFacilitator && <HostNotes introPortal />}
+      {isFacilitator && (
+        <>
+          <HostNotes introPortal />
+          <Spacer16 />
+        </>
+      )}
       <Wrapper>
         {isFocused && (
           <Content>


### PR DESCRIPTION
Issue: TopSafeArea was removed to allow host notes to go all the way up. This made the backbutton go up behind the safe area when there were no host notes.

This fixes that 😃
