### PR TITLE
Ugly video frame on iPhone 13 mini

### DIFF
--- a/client/src/routes/Temple/components/VideoBase/VideoBase.tsx
+++ b/client/src/routes/Temple/components/VideoBase/VideoBase.tsx
@@ -5,8 +5,8 @@ import {Platform} from 'react-native';
 
 const StyledVideo = styled(RNVideo)({
   flex: 1,
-  shadowOpacity: 1,
-  shadowColor: 'transparent',
+  shadowOpacity: 1, // Removes ugly frame on iPhone 13 mini (found in thread: https://github.com/react-native-video/react-native-video/issues/1638)
+  shadowColor: 'transparent', // Removes ugly frame on iPhone 13 mini (found in thread: https://github.com/react-native-video/react-native-video/issues/1638)
 });
 
 const getSilentSwitchSetting = () =>

--- a/client/src/routes/Temple/components/VideoBase/VideoBase.tsx
+++ b/client/src/routes/Temple/components/VideoBase/VideoBase.tsx
@@ -5,6 +5,8 @@ import {Platform} from 'react-native';
 
 const StyledVideo = styled(RNVideo)({
   flex: 1,
+  shadowOpacity: 1,
+  shadowColor: 'transparent',
 });
 
 const getSilentSwitchSetting = () =>


### PR DESCRIPTION
Issue: Ugly border on video on iPhone 13 mini ios15. Can't replicate on simulator. [More details in Notion](https://www.notion.so/29k/Closed-BETA-0055aabd797b40c7b390b7cea4eba658#979b6e9486764b6cbdd1084bb5441ea3) 
Found a [thread](https://github.com/react-native-video/react-native-video/issues/1638) suggesting adding a shadow might solve it.

This adds a transparent shadow. This can be tested on physical device (Marias) when it's out.