### PR TITLE
Prevent race condition in user re-creation

### DIFF
--- a/client/src/lib/apiClient/apiClient.spec.ts
+++ b/client/src/lib/apiClient/apiClient.spec.ts
@@ -138,6 +138,18 @@ describe('apiClient', () => {
     });
   });
 
+  it('does not run user recreation in parallel', async () => {
+    (auth().currentUser?.getIdToken as jest.Mock).mockResolvedValue(
+      'some-authorization-token',
+    );
+    fetchMock.mockResolvedValue({status: 401} as Response);
+
+    await Promise.all([apiClient('/some-path'), apiClient('/some-other-path')]);
+
+    expect(auth().signOut).toHaveBeenCalledTimes(1);
+    expect(auth().signInAnonymously).toHaveBeenCalledTimes(1);
+  });
+
   it('thows if authorization header from server fails on network error', async () => {
     (auth().currentUser?.getIdToken as jest.Mock)
       .mockRejectedValueOnce(new Error('Failed to get token'))

--- a/client/src/lib/apiClient/apiClient.ts
+++ b/client/src/lib/apiClient/apiClient.ts
@@ -2,11 +2,22 @@ import auth, {FirebaseAuthTypes} from '@react-native-firebase/auth';
 import {API_ENDPOINT} from 'config';
 import {getCorrelationId} from '../sentry';
 
-const recreateUser = async () => {
+const signOutAndSignIn = async () => {
   if (auth().currentUser) {
     await auth().signOut();
   }
   await auth().signInAnonymously();
+};
+
+let recreationPromise: undefined | Promise<void>;
+const recreateUser = async () => {
+  /* To prevent a race condition - re-use the promise to prevent this function to be run in parallel */
+  if (!recreationPromise) {
+    recreationPromise = signOutAndSignIn();
+  }
+
+  await recreationPromise;
+  recreationPromise = undefined;
 };
 
 const getAuthorizationToken = async (): Promise<string> => {


### PR DESCRIPTION
This prevents users to be re-created when multiple api calls calls for user re-creation in parallel.