### PR TITLE
Do not check codepush status if no deployment key is present

### DIFF
--- a/client/src/lib/codePush/hooks/useCheckForUpdate.ts
+++ b/client/src/lib/codePush/hooks/useCheckForUpdate.ts
@@ -70,14 +70,16 @@ const useCheckForUpdate = () => {
 
   return useCallback(async () => {
     try {
-      await codePush.sync(
-        {
-          mandatoryInstallMode: codePush.InstallMode.ON_NEXT_RESTART,
-          deploymentKey,
-        },
-        onStatus,
-        onProgress,
-      );
+      if (deploymentKey) {
+        await codePush.sync(
+          {
+            mandatoryInstallMode: codePush.InstallMode.ON_NEXT_RESTART,
+            deploymentKey,
+          },
+          onStatus,
+          onProgress,
+        );
+      }
     } catch (cause) {
       throw new Error('Code Push check failed', {cause});
     }


### PR DESCRIPTION
To get rid of this warning in development
![image](https://user-images.githubusercontent.com/474066/196362092-da7e3a8c-c98d-42ae-88ff-5fa3fcdbb3c5.png)
