### PR TITLE
Session type selection + Session controller/model

### DIFF
--- a/client/src/routes/Sessions/api/session.ts
+++ b/client/src/routes/Sessions/api/session.ts
@@ -3,14 +3,19 @@ import apiClient from '../../../lib/apiClient/apiClient';
 
 const SESSIONS_ENDPOINT = '/sessions';
 
-export const addSession = async (
-  contentId: Session['contentId'],
-  startTime: Session['startTime'],
-): Promise<Session> => {
+export const addSession = async ({
+  contentId,
+  type,
+  startTime,
+}: {
+  contentId: Session['contentId'];
+  type: Session['type'];
+  startTime: Session['startTime'];
+}): Promise<Session> => {
   try {
     const response = await apiClient(SESSIONS_ENDPOINT, {
       method: 'POST',
-      body: JSON.stringify({contentId, startTime}),
+      body: JSON.stringify({contentId, type, startTime}),
     });
 
     if (!response.ok) {

--- a/client/src/routes/Sessions/components/CreateSessionModal.tsx
+++ b/client/src/routes/Sessions/components/CreateSessionModal.tsx
@@ -178,6 +178,7 @@ const SelectType: React.FC<StepProps> = ({
       <Row>
         {Object.values(SessionType).map(type => (
           <TypeItem
+            key={type}
             onPress={() => {
               setSelectedType(type);
               nextStep();

--- a/client/src/routes/Sessions/components/CreateSessionModal.tsx
+++ b/client/src/routes/Sessions/components/CreateSessionModal.tsx
@@ -104,7 +104,7 @@ const ContentCard: React.FC<{
 };
 
 const SelectContent: React.FC<StepProps> = ({
-  setCurrentStep,
+  nextStep,
   setSelectedExercise,
 }) => {
   const exerciseIds = useExerciseIds();
@@ -128,7 +128,7 @@ const SelectContent: React.FC<StepProps> = ({
           <ContentCard
             onPress={() => {
               setSelectedExercise(item);
-              setCurrentStep(1);
+              nextStep();
             }}
             exerciseId={item}
           />
@@ -155,8 +155,7 @@ const TypeItem: React.FC<{
 const SelectType: React.FC<StepProps> = ({
   selectedExercise,
   setSelectedType,
-  currentStep,
-  setCurrentStep,
+  nextStep,
 }) => {
   const exercise = useExerciseById(selectedExercise);
   const {t} = useTranslation(NS.COMPONENT.CREATE_SESSION_MODAL);
@@ -181,7 +180,7 @@ const SelectType: React.FC<StepProps> = ({
           <TypeItem
             onPress={() => {
               setSelectedType(type);
-              setCurrentStep(currentStep + 1);
+              nextStep();
             }}
             label={t(`selectType.${type}.title`)}
             icon={t(`selectType.${type}.icon`)}
@@ -250,8 +249,7 @@ const SetDateTime: React.FC<StepProps> = ({selectedExercise, selectedType}) => {
 type StepProps = {
   selectedExercise: Exercise['id'] | undefined;
   setSelectedExercise: Dispatch<SetStateAction<StepProps['selectedExercise']>>;
-  currentStep: number;
-  setCurrentStep: Dispatch<SetStateAction<StepProps['currentStep']>>;
+  nextStep: () => void;
   selectedType: SessionType | undefined;
   setSelectedType: Dispatch<SetStateAction<StepProps['selectedType']>>;
 };
@@ -270,10 +268,9 @@ const CreateSessionModal = () => {
   const stepProps: StepProps = {
     selectedExercise,
     setSelectedExercise,
-    currentStep,
-    setCurrentStep,
     selectedType,
     setSelectedType,
+    nextStep: () => setCurrentStep(currentStep + 1),
   };
 
   return (

--- a/client/src/routes/Sessions/components/CreateSessionModal.tsx
+++ b/client/src/routes/Sessions/components/CreateSessionModal.tsx
@@ -192,7 +192,7 @@ const SelectType: React.FC<StepProps> = ({
   );
 };
 
-const SetDateTime: React.FC<StepProps> = ({selectedExercise}) => {
+const SetDateTime: React.FC<StepProps> = ({selectedExercise, selectedType}) => {
   const {t} = useTranslation(NS.COMPONENT.CREATE_SESSION_MODAL);
   const {goBack} = useNavigation();
   const [isLoading, setIsLoading] = useState(false);
@@ -202,11 +202,15 @@ const SetDateTime: React.FC<StepProps> = ({selectedExercise}) => {
   const exercise = useExerciseById(selectedExercise);
 
   const onSubmit = async () => {
-    if (selectedExercise && date && time) {
+    if (selectedExercise && selectedType && date && time) {
       const sessionDateTime = date.hour(time.hour()).minute(time.minute());
 
       setIsLoading(true);
-      await addSession(selectedExercise, sessionDateTime);
+      await addSession({
+        contentId: selectedExercise,
+        type: selectedType,
+        startTime: sessionDateTime,
+      });
       setIsLoading(false);
       goBack();
     }
@@ -248,7 +252,7 @@ type StepProps = {
   setSelectedExercise: Dispatch<SetStateAction<StepProps['selectedExercise']>>;
   currentStep: number;
   setCurrentStep: Dispatch<SetStateAction<StepProps['currentStep']>>;
-  selectedType: SessionType;
+  selectedType: SessionType | undefined;
   setSelectedType: Dispatch<SetStateAction<StepProps['selectedType']>>;
 };
 

--- a/client/src/routes/Sessions/hooks/useSessions.spec.ts
+++ b/client/src/routes/Sessions/hooks/useSessions.spec.ts
@@ -7,6 +7,7 @@ import {isLoadingAtom, sessionsAtom} from '../state/state';
 import {userAtom} from '../../../lib/user/state/state';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import {SessionType} from '../../../../../shared/src/types/Session';
 
 dayjs.extend(utc);
 
@@ -100,7 +101,11 @@ describe('useSessions', () => {
       });
 
       await act(async () => {
-        await result.current.addSession('some-content-id', startTime);
+        await result.current.addSession({
+          contentId: 'some-content-id',
+          type: SessionType.public,
+          startTime,
+        });
       });
 
       expect(fetchMock).toHaveBeenCalledWith('some-api-endpoint/sessions', {

--- a/client/src/routes/Sessions/hooks/useSessions.spec.ts
+++ b/client/src/routes/Sessions/hooks/useSessions.spec.ts
@@ -111,6 +111,7 @@ describe('useSessions', () => {
       expect(fetchMock).toHaveBeenCalledWith('some-api-endpoint/sessions', {
         body: JSON.stringify({
           contentId: 'some-content-id',
+          type: 'public',
           startTime: '1994-03-08T00:00:00.000Z',
         }),
         headers: {

--- a/client/src/routes/Sessions/hooks/useSessions.ts
+++ b/client/src/routes/Sessions/hooks/useSessions.ts
@@ -19,8 +19,20 @@ const useSessions = () => {
   }, [setIsLoading, setSessions]);
 
   const addSession = useCallback(
-    async (contentId: Session['contentId'], startTime: dayjs.Dayjs) => {
-      await sessionApi.addSession(contentId, startTime.toJSON());
+    async ({
+      contentId,
+      type,
+      startTime,
+    }: {
+      contentId: Session['contentId'];
+      type: Session['type'];
+      startTime: dayjs.Dayjs;
+    }) => {
+      await sessionApi.addSession({
+        contentId,
+        type,
+        startTime: startTime.toJSON(),
+      });
       fetchSessions();
     },
     [fetchSessions],

--- a/content/src/ui/Component.CreateSessionModal.json
+++ b/content/src/ui/Component.CreateSessionModal.json
@@ -3,6 +3,21 @@
     "selectContent": {
       "title": "Pick an exercise"
     },
+    "selectType": {
+      "title": "Create session with...",
+      "public": {
+        "title": "Anyone",
+        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+      },
+      "private": {
+        "title": "My friends",
+        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+      },
+      "async": {
+        "title": "My self",
+        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+      }
+    },
     "setDateTime": {
       "title": "Session time set up",
       "cta": "Publish"
@@ -12,6 +27,21 @@
     "selectContent": {
       "title": "Välj en övning"
     },
+    "selectType": {
+      "title": "Create session with...",
+      "public": {
+        "title": "Anyone",
+        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+      },
+      "private": {
+        "title": "My friends",
+        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+      },
+      "async": {
+        "title": "My self",
+        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+      }
+    },
     "setDateTime": {
       "title": "Välj en dag och tid",
       "cta": "Publisera"
@@ -20,6 +50,21 @@
   "pt": {
     "selectContent": {
       "title": "Escolha um exercício"
+    },
+    "selectType": {
+      "title": "Create session with...",
+      "public": {
+        "title": "Anyone",
+        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+      },
+      "private": {
+        "title": "My friends",
+        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+      },
+      "async": {
+        "title": "My self",
+        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+      }
     },
     "setDateTime": {
       "title": "Escolha o tempo da sessão",

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -13,6 +13,24 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "ended",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "startTime",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/functions/src/api/sessions/index.spec.ts
+++ b/functions/src/api/sessions/index.spec.ts
@@ -36,6 +36,7 @@ import {
 import {createRouter} from '../../lib/routers';
 import {firestore} from 'firebase-admin';
 import {Timestamp} from 'firebase-admin/firestore';
+import {SessionType} from '../../../../shared/src/types/Session';
 
 jest.mock('../../lib/dailyApi', () => mockDailyApi);
 jest.mock('../../lib/dynamicLinks', () => mockDynamicLinks);
@@ -145,6 +146,11 @@ describe('/api/sessions', () => {
         '>',
         expect.any(Timestamp),
       );
+    });
+
+    it('should filter for non-private sessions', async () => {
+      await request(mockServer).get('/sessions');
+      expect(mockWhere).toHaveBeenCalledWith('type', '!=', SessionType.private);
     });
 
     it('should order by startTime', async () => {

--- a/functions/src/api/sessions/index.spec.ts
+++ b/functions/src/api/sessions/index.spec.ts
@@ -161,6 +161,7 @@ describe('/api/sessions', () => {
         .post('/sessions')
         .send({
           contentId: 'some-content-id',
+          type: 'public',
           startTime,
         })
         .set('Accept', 'application/json');
@@ -180,10 +181,11 @@ describe('/api/sessions', () => {
         startTime: startTime,
         started: false,
         ended: false,
+        type: 'public',
       });
     });
 
-    it('should require a name', async () => {
+    it('should fail without session data', async () => {
       const response = await request(mockServer)
         .post('/sessions')
         .set('Accept', 'application/json');

--- a/functions/src/api/sessions/index.spec.ts
+++ b/functions/src/api/sessions/index.spec.ts
@@ -1,76 +1,21 @@
 import request from 'supertest';
-import {mockFirebase} from 'firestore-jest-mock';
 import Koa from 'koa';
-
-mockFirebase(
-  {
-    database: {
-      sessions: [],
-    },
-  },
-  {includeIdsInData: true, mutable: true},
-);
-
-const mockDailyApi = {
-  createRoom: jest.fn(() => ({
-    id: 'some-fake-daily-id',
-    url: 'http://fake.daily/url',
-  })),
-  deleteRoom: jest.fn(),
-};
-
-const mockDynamicLinks = {
-  createDynamicLink: jest.fn().mockResolvedValue('http://some.dynamic/link'),
-};
 
 import {sessionsRouter} from '.';
 import createMockServer from '../lib/createMockServer';
-import {
-  mockGetTransaction,
-  mockOrderBy,
-  mockRunTransaction,
-  mockUpdate,
-  mockUpdateTransaction,
-  mockWhere,
-} from 'firestore-jest-mock/mocks/firestore';
 import {createRouter} from '../../lib/routers';
-import {firestore} from 'firebase-admin';
-import {Timestamp} from 'firebase-admin/firestore';
-import {SessionType} from '../../../../shared/src/types/Session';
+import * as sessionsController from '../../controllers/sessions';
+import * as sessionModel from '../../models/session';
 
-jest.mock('../../lib/dailyApi', () => mockDailyApi);
-jest.mock('../../lib/dynamicLinks', () => mockDynamicLinks);
+jest.mock('../../controllers/sessions');
+const mockCreateSession = sessionsController.createSession as jest.Mock;
+const mockRemoveSession = sessionsController.removeSession as jest.Mock;
+const mockUpdateSession = sessionsController.updateSession as jest.Mock;
+const mockUpdateExerciseState =
+  sessionsController.updateExerciseState as jest.Mock;
 
-const sessions = [
-  {
-    id: 'some-session-id',
-    name: 'some-name',
-    url: 'some-url',
-    exerciseState: {
-      index: 0,
-      playing: false,
-      timestamp: Timestamp.now(),
-    },
-    facilitator: 'some-user-id',
-    startTime: Timestamp.now(),
-    started: false,
-    ended: false,
-  },
-  {
-    id: 'some-other-session-id',
-    name: 'some-other-name',
-    url: 'some-other-url',
-    exerciseState: {
-      index: 0,
-      playing: false,
-      timestamp: Timestamp.now(),
-    },
-    facilitator: 'some-other-user-id',
-    startTime: Timestamp.now(),
-    started: false,
-    ended: false,
-  },
-];
+jest.mock('../../models/session');
+const mockGetSessions = sessionModel.getSessions as jest.Mock;
 
 const router = createRouter();
 router.use('/sessions', sessionsRouter.routes());
@@ -85,14 +30,6 @@ const mockServer = createMockServer(
   router.allowedMethods(),
 );
 
-beforeEach(async () => {
-  await Promise.all(
-    sessions.map(session =>
-      firestore().collection('sessions').doc(session.id).set(session),
-    ),
-  );
-});
-
 afterEach(() => {
   jest.clearAllMocks();
 });
@@ -104,7 +41,39 @@ afterAll(() => {
 describe('/api/sessions', () => {
   describe('GET', () => {
     it('should get sessions', async () => {
+      mockGetSessions.mockResolvedValue([
+        {
+          id: 'some-session-id',
+          name: 'some-name',
+          url: 'some-url',
+          exerciseState: {
+            index: 0,
+            playing: false,
+            timestamp: new Date('2022-10-10T10:00:00Z').toISOString(),
+          },
+          facilitator: 'some-user-id',
+          startTime: new Date('2022-10-10T10:00:00Z').toISOString(),
+          started: false,
+          ended: false,
+        },
+        {
+          id: 'some-other-session-id',
+          name: 'some-other-name',
+          url: 'some-other-url',
+          exerciseState: {
+            index: 0,
+            playing: false,
+            timestamp: new Date('2022-10-10T10:00:00Z').toISOString(),
+          },
+          facilitator: 'some-other-user-id',
+          startTime: new Date('2022-10-10T10:00:00Z').toISOString(),
+          started: false,
+          ended: false,
+        },
+      ]);
+
       const response = await request(mockServer).get('/sessions');
+
       expect(response.status).toBe(200);
       expect(response.body).toEqual([
         {
@@ -137,32 +106,13 @@ describe('/api/sessions', () => {
         },
       ]);
     });
-
-    it('should filter out old sessions', async () => {
-      await request(mockServer).get('/sessions');
-      expect(mockWhere).toHaveBeenCalledWith('ended', '==', false);
-      expect(mockWhere).toHaveBeenCalledWith(
-        'startTime',
-        '>',
-        expect.any(Timestamp),
-      );
-    });
-
-    it('should filter for non-private sessions', async () => {
-      await request(mockServer).get('/sessions');
-      expect(mockWhere).toHaveBeenCalledWith('type', '!=', SessionType.private);
-    });
-
-    it('should order by startTime', async () => {
-      await request(mockServer).get('/sessions');
-      expect(mockOrderBy).toHaveBeenCalledWith('startTime', 'asc');
-    });
   });
 
   describe('POST', () => {
     const startTime = new Date('1994-03-08T07:24:00').toISOString();
 
     it('should return newly created session', async () => {
+      mockCreateSession.mockResolvedValueOnce({id: 'new-session'});
       const response = await request(mockServer)
         .post('/sessions')
         .send({
@@ -174,20 +124,7 @@ describe('/api/sessions', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
-        id: 'some-fake-daily-id',
-        url: 'http://fake.daily/url',
-        link: 'http://some.dynamic/link',
-        exerciseState: {
-          index: 0,
-          playing: false,
-          timestamp: expect.any(String),
-        },
-        contentId: 'some-content-id',
-        facilitator: 'some-user-id',
-        startTime: startTime,
-        started: false,
-        ended: false,
-        type: 'public',
+        id: 'new-session',
       });
     });
 
@@ -200,8 +137,8 @@ describe('/api/sessions', () => {
       expect(response.text).toEqual('Internal Server Error');
     });
 
-    it('should fail if daily api fails', async () => {
-      mockDailyApi.createRoom.mockRejectedValueOnce(
+    it('should fail if controller throws', async () => {
+      mockCreateSession.mockRejectedValueOnce(
         new Error('some error text') as never,
       );
       const response = await request(mockServer)
@@ -212,7 +149,8 @@ describe('/api/sessions', () => {
   });
 
   describe('PUT', () => {
-    it('should return updated session with started', async () => {
+    it('should return updated session', async () => {
+      mockUpdateSession.mockResolvedValueOnce({id: 'some-session-id'});
       const response = await request(mockServer)
         .put('/sessions/some-session-id')
         .send({started: true})
@@ -221,40 +159,6 @@ describe('/api/sessions', () => {
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
         id: 'some-session-id',
-        name: 'some-name',
-        url: 'some-url',
-        exerciseState: {
-          index: 0,
-          playing: false,
-          timestamp: expect.any(String),
-        },
-        facilitator: 'some-user-id',
-        startTime: expect.any(String),
-        started: true,
-        ended: false,
-      });
-    });
-
-    it('should return updated session with ended', async () => {
-      const response = await request(mockServer)
-        .put('/sessions/some-session-id')
-        .send({ended: true})
-        .set('Accept', 'application/json');
-
-      expect(response.status).toBe(200);
-      expect(response.body).toEqual({
-        id: 'some-session-id',
-        name: 'some-name',
-        url: 'some-url',
-        exerciseState: {
-          index: 0,
-          playing: false,
-          timestamp: expect.any(String),
-        },
-        facilitator: 'some-user-id',
-        startTime: expect.any(String),
-        started: false,
-        ended: true,
       });
     });
 
@@ -267,7 +171,8 @@ describe('/api/sessions', () => {
       expect(response.status).toBe(500);
     });
 
-    it('should fail when request auth user is not facilitator', async () => {
+    it('should fail when update rejects', async () => {
+      mockUpdateSession.mockRejectedValueOnce(new Error('some-error'));
       const response = await request(mockServer)
         .put('/sessions/some-other-session-id')
         .send({started: true})
@@ -279,18 +184,8 @@ describe('/api/sessions', () => {
   });
 
   describe('PUT /:id/exerciseState', () => {
-    it('runs in a transaction', async () => {
-      await request(mockServer)
-        .put('/sessions/some-session-id/exerciseState')
-        .send({playing: true})
-        .set('Accept', 'application/json');
-
-      expect(mockRunTransaction).toHaveBeenCalledTimes(1);
-      expect(mockUpdateTransaction).toHaveBeenCalledTimes(1);
-      expect(mockGetTransaction).toHaveBeenCalledTimes(1);
-    });
-
-    it('should update index', async () => {
+    it('should call session update', async () => {
+      mockUpdateExerciseState.mockResolvedValueOnce({id: 'some-session-id'});
       const response = await request(mockServer)
         .put('/sessions/some-session-id/exerciseState')
         .send({index: 2})
@@ -299,68 +194,11 @@ describe('/api/sessions', () => {
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
         id: 'some-session-id',
-        name: 'some-name',
-        url: 'some-url',
-        exerciseState: {
-          index: 2,
-          playing: false,
-          timestamp: expect.any(String),
-        },
-        facilitator: 'some-user-id',
-        startTime: expect.any(String),
-        started: false,
-        ended: false,
       });
     });
 
-    it('should update playing', async () => {
-      const response = await request(mockServer)
-        .put('/sessions/some-session-id/exerciseState')
-        .send({playing: true})
-        .set('Accept', 'application/json');
-
-      expect(response.status).toBe(200);
-      expect(response.body).toEqual({
-        id: 'some-session-id',
-        name: 'some-name',
-        url: 'some-url',
-        exerciseState: {
-          index: 0,
-          playing: true,
-          timestamp: expect.any(String),
-        },
-        facilitator: 'some-user-id',
-        startTime: expect.any(String),
-        started: false,
-        ended: false,
-      });
-    });
-
-    it('should update dailySpotlightId', async () => {
-      const response = await request(mockServer)
-        .put('/sessions/some-session-id/exerciseState')
-        .send({dailySpotlightId: 'some-user-id'})
-        .set('Accept', 'application/json');
-
-      expect(response.status).toBe(200);
-      expect(response.body).toEqual({
-        id: 'some-session-id',
-        name: 'some-name',
-        url: 'some-url',
-        exerciseState: {
-          index: 0,
-          playing: false,
-          dailySpotlightId: 'some-user-id',
-          timestamp: expect.any(String),
-        },
-        facilitator: 'some-user-id',
-        startTime: expect.any(String),
-        started: false,
-        ended: false,
-      });
-    });
-
-    it('should fail when request auth user is not facilitator', async () => {
+    it('should fail when update rejects', async () => {
+      mockUpdateExerciseState.mockRejectedValueOnce(new Error('some-error'));
       const response = await request(mockServer)
         .put('/sessions/some-other-session-id/exerciseState')
         .send({playing: true})
@@ -377,64 +215,37 @@ describe('/api/sessions', () => {
 
       expect(response.status).toBe(500);
       expect(response.text).toEqual('Internal Server Error');
-      expect(mockUpdate).toHaveBeenCalledTimes(0);
+      expect(mockUpdateExerciseState).toHaveBeenCalledTimes(0);
     });
 
     it('does not accept other fields', async () => {
+      mockUpdateExerciseState.mockResolvedValueOnce({id: 'some-session-id'});
       const response = await request(mockServer)
         .put('/sessions/some-session-id/exerciseState')
         .send({index: 1, foo: 'bar'})
         .set('Accept', 'application/json');
 
       expect(response.status).toBe(200);
-      expect(mockUpdateTransaction).toHaveBeenCalledTimes(1);
-      expect(mockUpdateTransaction).toHaveBeenCalledWith(expect.any(Object), {
-        exerciseState: {
+      expect(mockUpdateExerciseState).toHaveBeenCalledTimes(1);
+      expect(mockUpdateExerciseState).toHaveBeenCalledWith(
+        'some-user-id',
+        'some-session-id',
+        {
           index: 1,
-          playing: false,
-          timestamp: expect.any(Object),
         },
-      });
-    });
-
-    it('should return 500 on non-existing session', async () => {
-      const response = await request(mockServer)
-        .put('/sessions/some-non-existing-id/exerciseState')
-        .send({index: 1})
-        .set('Accept', 'application/json');
-
-      expect(response.status).toBe(500);
-      expect(response.text).toEqual('Internal Server Error');
-      expect(mockUpdate).toHaveBeenCalledTimes(0);
+      );
     });
   });
 
   describe('DELETE', () => {
     it('should delete and confirm on response', async () => {
+      mockRemoveSession.mockResolvedValue(undefined);
       const response = await request(mockServer)
         .delete('/sessions/some-session-id')
         .set('Accept', 'application/json');
 
       expect(response.status).toBe(200);
       expect(response.text).toEqual('Session deleted successfully');
-    });
-
-    it('should fail when non-existing session id', async () => {
-      const response = await request(mockServer)
-        .delete('/sessions/some-non-existent-session-id')
-        .set('Accept', 'application/json');
-
-      expect(response.status).toBe(500);
-      expect(response.text).toEqual('Internal Server Error');
-    });
-
-    it('should fail when request auth user is not facilitator', async () => {
-      const response = await request(mockServer)
-        .delete('/sessions/some-other-session-id')
-        .set('Accept', 'application/json');
-
-      expect(response.status).toBe(500);
-      expect(response.text).toEqual('Internal Server Error');
     });
   });
 });

--- a/functions/src/api/sessions/index.ts
+++ b/functions/src/api/sessions/index.ts
@@ -10,6 +10,7 @@ import {
   Session,
   ExerciseStateData,
   ExerciseState,
+  SessionType,
 } from '../../../../shared/src/types/Session';
 import * as dailyApi from '../../lib/dailyApi';
 import {createRouter} from '../../lib/routers';
@@ -59,13 +60,14 @@ sessionsRouter.get('/', async ctx => {
 
 const CreateSessionSchema = yup.object().shape({
   contentId: yup.string().required(),
+  type: yup.mixed<SessionType>().oneOf(Object.values(SessionType)).required(),
   startTime: yup.string().required(),
 });
 
 type CreateSession = yup.InferType<typeof CreateSessionSchema>;
 
 sessionsRouter.post('/', validator({body: CreateSessionSchema}), async ctx => {
-  const {contentId, startTime} = ctx.request.body as CreateSession;
+  const {contentId, type, startTime} = ctx.request.body as CreateSession;
 
   const startDateTime = dayjs(startTime);
 
@@ -91,6 +93,7 @@ sessionsRouter.post('/', validator({body: CreateSessionSchema}), async ctx => {
     exerciseState: defaultExerciseState,
     started: false,
     ended: false,
+    type,
   };
 
   await firestore().collection(SESSIONS_COLLECTION).doc(data.id).set(session);

--- a/functions/src/api/sessions/index.ts
+++ b/functions/src/api/sessions/index.ts
@@ -48,7 +48,7 @@ sessionsRouter.get('/', async ctx => {
         dayjs(Timestamp.now().toDate()).subtract(30, 'minute').toDate(),
       ),
     )
-    .where('type', '==', 'public')
+    .where('type', '!=', SessionType.private)
     .orderBy('startTime', 'asc')
     .get();
   const sessions = snapshot.docs.map(doc =>

--- a/functions/src/api/sessions/index.ts
+++ b/functions/src/api/sessions/index.ts
@@ -48,6 +48,7 @@ sessionsRouter.get('/', async ctx => {
         dayjs(Timestamp.now().toDate()).subtract(30, 'minute').toDate(),
       ),
     )
+    .where('type', '==', 'public')
     .orderBy('startTime', 'asc')
     .get();
   const sessions = snapshot.docs.map(doc =>

--- a/functions/src/api/sessions/index.ts
+++ b/functions/src/api/sessions/index.ts
@@ -2,6 +2,7 @@ import * as yup from 'yup';
 import validator from 'koa-yup-validator';
 import 'firebase-functions';
 import dayjs from 'dayjs';
+import 'firebase-functions';
 
 import {Session, SessionType} from '../../../../shared/src/types/Session';
 import * as dailyApi from '../../lib/dailyApi';

--- a/functions/src/api/sessions/index.ts
+++ b/functions/src/api/sessions/index.ts
@@ -56,7 +56,6 @@ sessionsRouter.post('/', validator({body: CreateSessionSchema}), async ctx => {
       type,
       startTime,
       facilitator: user.id,
-      userIds: type === SessionType.private ? [user.id] : ['all'],
     });
 
     ctx.body = session;

--- a/functions/src/controllers/__mocks__/sessions.ts
+++ b/functions/src/controllers/__mocks__/sessions.ts
@@ -1,0 +1,4 @@
+export const createSession = jest.fn();
+export const removeSession = jest.fn();
+export const updateSession = jest.fn();
+export const updateExerciseState = jest.fn();

--- a/functions/src/controllers/sessions.spec.ts
+++ b/functions/src/controllers/sessions.spec.ts
@@ -1,0 +1,178 @@
+const mockDynamicLinks = {
+  createDynamicLink: jest.fn().mockResolvedValue('http://some.dynamic/link'),
+};
+const mockDailyApi = {
+  createRoom: jest.fn(() => ({
+    id: 'some-fake-daily-id',
+    url: 'http://fake.daily/url',
+    name: 'some-fake-daily-room-name',
+  })),
+  deleteRoom: jest.fn(),
+};
+
+import * as sessionModel from '../models/session';
+import {
+  createSession,
+  removeSession,
+  updateExerciseState,
+  updateSession,
+} from './sessions';
+import {SessionType} from '../../../shared/src/types/Session';
+import dayjs from 'dayjs';
+
+jest.mock('../lib/dailyApi', () => mockDailyApi);
+jest.mock('../lib/dynamicLinks', () => mockDynamicLinks);
+jest.mock('../models/session');
+
+const mockAddSession = sessionModel.addSession as jest.Mock;
+const mockGetSessionById = sessionModel.getSessionById as jest.Mock;
+const mockDeleteSession = sessionModel.deleteSession as jest.Mock;
+const mockUpdateSession = sessionModel.updateSession as jest.Mock;
+const mockUpdateExerciseState = sessionModel.updateExerciseState as jest.Mock;
+
+jest.useFakeTimers().setSystemTime(new Date('2022-10-10T09:00:00Z'));
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+});
+
+describe('sessions - conroller', () => {
+  describe('createSession', () => {
+    it('should create a daily room that expires 2h after it starts', async () => {
+      await createSession('some-user-id', {
+        contentId: 'some-content-id',
+        type: SessionType.public,
+        startTime: new Date('2022-10-10T10:00:00Z').toISOString(),
+      });
+
+      const expireDate = dayjs('2022-10-10T12:00:00.000Z');
+      expect(mockDailyApi.createRoom).toHaveBeenCalledWith(expireDate);
+    });
+
+    it('should create a dynamic link with correct path', async () => {
+      await createSession('some-user-id', {
+        contentId: 'some-content-id',
+        type: SessionType.public,
+        startTime: new Date('2022-10-10T10:00:00Z').toISOString(),
+      });
+      expect(mockDynamicLinks.createDynamicLink).toHaveBeenCalledWith(
+        'sessions/some-fake-daily-id',
+      );
+    });
+
+    it('should create and return a session', async () => {
+      mockAddSession.mockResolvedValueOnce('add-session-resolved-value');
+      const session = await createSession('some-user-id', {
+        contentId: 'some-content-id',
+        type: SessionType.public,
+        startTime: new Date('2022-10-10T10:00:00Z').toISOString(),
+      });
+
+      expect(mockAddSession).toHaveBeenCalledWith({
+        contentId: 'some-content-id',
+        dailyRoomName: 'some-fake-daily-room-name',
+        facilitator: 'some-user-id',
+        id: 'some-fake-daily-id',
+        link: 'http://some.dynamic/link',
+        startTime: '2022-10-10T10:00:00.000Z',
+        type: 'public',
+        url: 'http://fake.daily/url',
+      });
+      expect(session).toBe('add-session-resolved-value');
+    });
+  });
+
+  describe('removeSession', () => {
+    it('should throw if user is not the host', async () => {
+      mockGetSessionById.mockResolvedValue({facilitator: 'the-host-id'});
+      await expect(
+        removeSession('not-the-host-id', 'some-session-id'),
+      ).rejects.toEqual(Error('user-unauthorized'));
+    });
+
+    it('should delete session and daily room', async () => {
+      mockGetSessionById.mockResolvedValue({
+        id: 'some-session-id',
+        dailyRoomName: 'some-daily-room-name',
+        facilitator: 'the-host-id',
+      });
+
+      await removeSession('the-host-id', 'some-session-id');
+
+      expect(mockDailyApi.deleteRoom).toHaveBeenCalledWith(
+        'some-daily-room-name',
+      );
+      expect(mockDeleteSession).toHaveBeenCalledWith('some-session-id');
+    });
+  });
+
+  describe('updateSession', () => {
+    it('should throw if user is not the host', async () => {
+      mockGetSessionById.mockResolvedValue({facilitator: 'the-host-id'});
+      await expect(
+        updateSession('not-the-host-id', 'some-session-id', {started: true}),
+      ).rejects.toEqual(Error('user-unauthorized'));
+    });
+
+    it('should update the session and return it', async () => {
+      mockGetSessionById.mockResolvedValueOnce({
+        id: 'some-session-id',
+        dailyRoomName: 'some-daily-room-name',
+        facilitator: 'the-host-id',
+      });
+      mockGetSessionById.mockResolvedValueOnce({
+        id: 'some-session-id',
+        started: true,
+      }); // second call (returned value)
+
+      const updatedSession = await updateSession(
+        'the-host-id',
+        'some-session-id',
+        {started: true},
+      );
+      expect(mockUpdateSession).toHaveBeenCalledWith('some-session-id', {
+        started: true,
+      });
+      expect(updatedSession).toEqual({
+        id: 'some-session-id',
+        started: true,
+      });
+    });
+  });
+
+  describe('updateExerciseState', () => {
+    it('should throw if user is not the host', async () => {
+      mockGetSessionById.mockResolvedValue({facilitator: 'the-host-id'});
+      await expect(
+        updateExerciseState('not-the-host-id', 'some-session-id', {
+          index: 1,
+        }),
+      ).rejects.toEqual(Error('user-unauthorized'));
+    });
+
+    it('should update the session and return it', async () => {
+      mockGetSessionById.mockResolvedValueOnce({
+        id: 'some-session-id',
+        dailyRoomName: 'some-daily-room-name',
+        facilitator: 'the-host-id',
+      });
+      mockGetSessionById.mockResolvedValueOnce({
+        id: 'some-session-id',
+        exerciseState: {index: 1},
+      }); // second call (returned value)
+
+      const updatedSession = await updateExerciseState(
+        'the-host-id',
+        'some-session-id',
+        {index: 1},
+      );
+      expect(mockUpdateExerciseState).toHaveBeenCalledWith('some-session-id', {
+        index: 1,
+      });
+      expect(updatedSession).toEqual({
+        id: 'some-session-id',
+        exerciseState: {index: 1},
+      });
+    });
+  });
+});

--- a/functions/src/controllers/sessions.spec.ts
+++ b/functions/src/controllers/sessions.spec.ts
@@ -104,6 +104,17 @@ describe('sessions - conroller', () => {
       );
       expect(mockDeleteSession).toHaveBeenCalledWith('some-session-id');
     });
+
+    it('should just resolve if session is not found', async () => {
+      mockGetSessionById.mockResolvedValue(undefined);
+
+      await expect(
+        removeSession('the-host-id', 'some-session-id'),
+      ).resolves.toBe(undefined);
+
+      expect(mockDailyApi.deleteRoom).toHaveBeenCalledTimes(0);
+      expect(mockDeleteSession).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe('updateSession', () => {
@@ -148,6 +159,15 @@ describe('sessions - conroller', () => {
           index: 1,
         }),
       ).rejects.toEqual(Error('user-unauthorized'));
+    });
+
+    it('should throw if session is not found', async () => {
+      mockGetSessionById.mockResolvedValue(undefined);
+      await expect(
+        updateExerciseState('not-the-host-id', 'some-session-id', {
+          index: 1,
+        }),
+      ).rejects.toEqual(Error('session-not-found'));
     });
 
     it('should update the session and return it', async () => {

--- a/functions/src/controllers/sessions.ts
+++ b/functions/src/controllers/sessions.ts
@@ -1,0 +1,82 @@
+import dayjs from 'dayjs';
+import {createDynamicLink} from '../lib/dynamicLinks';
+import * as sessionModel from '../models/session';
+import * as dailyApi from '../lib/dailyApi';
+import {Session} from '../../../shared/src/types/Session';
+import {ExerciseStateUpdate, UpdateSession} from '../api/sessions';
+import {removeEmpty} from '../lib/utils';
+
+export const createSession = async (
+  userId: string,
+  {
+    contentId,
+    type,
+    startTime,
+  }: Pick<Session, 'contentId' | 'type' | 'startTime'>,
+) => {
+  const dailyRoom = await dailyApi.createRoom(dayjs(startTime).add(2, 'hour'));
+  const link = await createDynamicLink(`sessions/${dailyRoom.id}`);
+
+  return sessionModel.addSession({
+    id: dailyRoom.id,
+    dailyRoomName: dailyRoom.name,
+    url: dailyRoom.url,
+    contentId,
+    link,
+    type,
+    startTime,
+    facilitator: userId,
+  });
+};
+
+export const removeSession = async (
+  userId: string,
+  sessionId: Session['id'],
+) => {
+  const session = (await sessionModel.getSessionById(sessionId)) as Session & {
+    dailyRoomName: string;
+  };
+
+  if (userId !== session?.facilitator) {
+    throw new Error('user-unauthorized');
+  }
+
+  await Promise.all([
+    dailyApi.deleteRoom(session.dailyRoomName),
+    sessionModel.deleteSession(session.id),
+  ]);
+};
+
+export const updateSession = async (
+  userId: string,
+  sessionId: Session['id'],
+  data: Partial<UpdateSession>,
+) => {
+  const session = (await sessionModel.getSessionById(sessionId)) as Session & {
+    dailyRoomName: string;
+  };
+
+  if (userId !== session?.facilitator) {
+    throw new Error('user-unauthorized');
+  }
+
+  await sessionModel.updateSession(sessionId, removeEmpty(data));
+  return sessionModel.getSessionById(sessionId);
+};
+
+export const updateExerciseState = async (
+  userId: string,
+  sessionId: Session['id'],
+  data: Partial<ExerciseStateUpdate>,
+) => {
+  const session = (await sessionModel.getSessionById(sessionId)) as Session & {
+    dailyRoomName: string;
+  };
+
+  if (userId !== session?.facilitator) {
+    throw new Error('user-unauthorized');
+  }
+
+  await sessionModel.updateExerciseState(sessionId, removeEmpty(data));
+  return sessionModel.getSessionById(sessionId);
+};

--- a/functions/src/controllers/sessions.ts
+++ b/functions/src/controllers/sessions.ts
@@ -37,6 +37,8 @@ export const removeSession = async (
     dailyRoomName: string;
   };
 
+  if (!session) return;
+
   if (userId !== session?.facilitator) {
     throw new Error('user-unauthorized');
   }
@@ -72,6 +74,10 @@ export const updateExerciseState = async (
   const session = (await sessionModel.getSessionById(sessionId)) as Session & {
     dailyRoomName: string;
   };
+
+  if (!session) {
+    throw new Error('session-not-found');
+  }
 
   if (userId !== session?.facilitator) {
     throw new Error('user-unauthorized');

--- a/functions/src/models/__mocks__/session.ts
+++ b/functions/src/models/__mocks__/session.ts
@@ -1,0 +1,6 @@
+export const getSessionById = jest.fn();
+export const getSessions = jest.fn();
+export const addSession = jest.fn();
+export const deleteSession = jest.fn();
+export const updateSession = jest.fn();
+export const updateExerciseState = jest.fn();

--- a/functions/src/models/session.spec.ts
+++ b/functions/src/models/session.spec.ts
@@ -1,0 +1,332 @@
+import {mockFirebase} from 'firestore-jest-mock';
+
+mockFirebase(
+  {
+    database: {
+      sessions: [],
+    },
+  },
+  {includeIdsInData: true, mutable: true},
+);
+
+import {
+  mockCollection,
+  mockGetTransaction,
+  mockOrderBy,
+  mockRunTransaction,
+  mockUpdateTransaction,
+  mockWhere,
+  mockDelete,
+  mockDoc,
+} from 'firestore-jest-mock/mocks/firestore';
+import {firestore} from 'firebase-admin';
+import {Timestamp} from 'firebase-admin/firestore';
+
+import {
+  addSession,
+  deleteSession,
+  getSessions,
+  updateExerciseState,
+  updateSession,
+} from './session';
+import {SessionType} from '../../../shared/src/types/Session';
+
+const sessions = [
+  {
+    id: 'some-session-id',
+    name: 'some-name',
+    url: 'some-url',
+    exerciseState: {
+      index: 0,
+      playing: false,
+      timestamp: Timestamp.now(),
+    },
+    facilitator: 'some-user-id',
+    startTime: Timestamp.now(),
+    started: false,
+    ended: false,
+    userIds: ['all'],
+  },
+  {
+    id: 'some-other-session-id',
+    name: 'some-other-name',
+    url: 'some-other-url',
+    exerciseState: {
+      index: 0,
+      playing: false,
+      timestamp: Timestamp.now(),
+    },
+    facilitator: 'some-other-user-id',
+    startTime: Timestamp.now(),
+    started: false,
+    ended: false,
+    userIds: ['all'],
+  },
+];
+
+beforeEach(async () => {
+  await Promise.all(
+    sessions.map(session =>
+      firestore().collection('sessions').doc(session.id).set(session),
+    ),
+  );
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('session model', () => {
+  describe('getSessions', () => {
+    it('should get sessions', async () => {
+      const sessions = await getSessions('some-non-id');
+      expect(sessions).toEqual([
+        {
+          ended: false,
+          exerciseState: {
+            index: 0,
+            playing: false,
+            timestamp: expect.any(String),
+          },
+          facilitator: 'some-user-id',
+          id: 'some-session-id',
+          name: 'some-name',
+          startTime: expect.any(String),
+          started: false,
+          url: 'some-url',
+          userIds: ['all'],
+        },
+        {
+          ended: false,
+          exerciseState: {
+            index: 0,
+            playing: false,
+            timestamp: expect.any(String),
+          },
+          facilitator: 'some-other-user-id',
+          id: 'some-other-session-id',
+          name: 'some-other-name',
+          startTime: expect.any(String),
+          started: false,
+          url: 'some-other-url',
+          userIds: ['all'],
+        },
+      ]);
+    });
+
+    it('should filter out old sessions', async () => {
+      await getSessions('some-user-id');
+      expect(mockWhere).toHaveBeenCalledWith('ended', '==', false);
+      expect(mockWhere).toHaveBeenCalledWith(
+        'startTime',
+        '>',
+        expect.any(Timestamp),
+      );
+    });
+
+    it('should filter for public sessions and sessions that the user belongs to', async () => {
+      await getSessions('some-user-id');
+      expect(mockWhere).toHaveBeenCalledWith('userIds', 'array-contains-any', [
+        'all',
+        'some-user-id',
+      ]);
+    });
+
+    it('should order by startime', async () => {
+      await getSessions('some-user-id');
+      expect(mockOrderBy).toHaveBeenCalledWith('startTime', 'asc');
+    });
+  });
+
+  describe('addSession', () => {
+    const startTime = new Date('1994-03-08T07:24:00').toISOString();
+
+    it('should return public session', async () => {
+      const session = await addSession({
+        id: 'session-id',
+        dailyRoomName: 'daily-room-name',
+        url: 'daily-url',
+        contentId: 'content-id',
+        link: 'deep-link',
+        type: SessionType.public,
+        startTime: startTime,
+        facilitator: 'some-user-id',
+      });
+
+      expect(session).toEqual({
+        contentId: 'content-id',
+        dailyRoomName: 'daily-room-name',
+        ended: false,
+        exerciseState: {
+          index: 0,
+          playing: false,
+          timestamp: expect.any(String),
+        },
+        facilitator: 'some-user-id',
+        id: 'session-id',
+        link: 'deep-link',
+        startTime: startTime,
+        started: false,
+        type: 'public',
+        url: 'daily-url',
+        userIds: ['all'],
+      });
+    });
+
+    it('should return private session', async () => {
+      const session = await addSession({
+        id: 'session-id',
+        dailyRoomName: 'daily-room-name',
+        url: 'daily-url',
+        contentId: 'content-id',
+        link: 'deep-link',
+        type: SessionType.private,
+        startTime: startTime,
+        facilitator: 'some-user-id',
+      });
+
+      expect(session).toEqual({
+        contentId: 'content-id',
+        dailyRoomName: 'daily-room-name',
+        ended: false,
+        exerciseState: {
+          index: 0,
+          playing: false,
+          timestamp: expect.any(String),
+        },
+        facilitator: 'some-user-id',
+        id: 'session-id',
+        link: 'deep-link',
+        startTime: startTime,
+        started: false,
+        type: 'private',
+        url: 'daily-url',
+        userIds: ['some-user-id'],
+      });
+    });
+  });
+
+  describe('updateSession', () => {
+    it('should return updated session with started', async () => {
+      const session = await updateSession('some-session-id', {started: true});
+
+      expect(session).toEqual({
+        id: 'some-session-id',
+        name: 'some-name',
+        url: 'some-url',
+        exerciseState: {
+          index: 0,
+          playing: false,
+          timestamp: expect.any(String),
+        },
+        facilitator: 'some-user-id',
+        startTime: expect.any(String),
+        started: true,
+        ended: false,
+        userIds: ['all'],
+      });
+    });
+
+    it('should return updated session with ended', async () => {
+      const session = await updateSession('some-session-id', {ended: true});
+
+      expect(session).toEqual({
+        id: 'some-session-id',
+        name: 'some-name',
+        url: 'some-url',
+        exerciseState: {
+          index: 0,
+          playing: false,
+          timestamp: expect.any(String),
+        },
+        facilitator: 'some-user-id',
+        startTime: expect.any(String),
+        started: false,
+        ended: true,
+        userIds: ['all'],
+      });
+    });
+  });
+
+  describe('updateExerciseState', () => {
+    it('should update playing', async () => {
+      const session = await updateExerciseState('some-session-id', {
+        playing: true,
+      });
+
+      expect(mockRunTransaction).toHaveBeenCalledTimes(1);
+      expect(mockUpdateTransaction).toHaveBeenCalledTimes(1);
+      expect(mockGetTransaction).toHaveBeenCalledTimes(1);
+      expect(session).toEqual({
+        ended: false,
+        exerciseState: {
+          index: 0,
+          playing: true,
+          timestamp: expect.any(String),
+        },
+        facilitator: 'some-user-id',
+        id: 'some-session-id',
+        name: 'some-name',
+        startTime: expect.any(String),
+        started: false,
+        url: 'some-url',
+        userIds: ['all'],
+      });
+    });
+
+    it('should update index', async () => {
+      const session = await updateExerciseState('some-session-id', {
+        index: 2,
+      });
+
+      expect(session).toEqual({
+        id: 'some-session-id',
+        name: 'some-name',
+        url: 'some-url',
+        exerciseState: {
+          index: 2,
+          playing: false,
+          timestamp: expect.any(String),
+        },
+        facilitator: 'some-user-id',
+        startTime: expect.any(String),
+        started: false,
+        ended: false,
+        userIds: ['all'],
+      });
+    });
+
+    it('should update dailySpotlightId', async () => {
+      const session = await updateExerciseState('some-session-id', {
+        dailySpotlightId: 'some-user-id',
+      });
+
+      expect(session).toEqual({
+        id: 'some-session-id',
+        name: 'some-name',
+        url: 'some-url',
+        exerciseState: {
+          index: 0,
+          playing: false,
+          dailySpotlightId: 'some-user-id',
+          timestamp: expect.any(String),
+        },
+        facilitator: 'some-user-id',
+        startTime: expect.any(String),
+        started: false,
+        ended: false,
+        userIds: ['all'],
+      });
+    });
+  });
+
+  describe('DELETE', () => {
+    it('should delete and confirm on response', async () => {
+      await deleteSession('some-session-id');
+
+      expect(mockCollection).toHaveBeenCalledWith('sessions');
+      expect(mockDoc).toHaveBeenCalledWith('some-session-id');
+      expect(mockDelete).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/functions/src/models/session.spec.ts
+++ b/functions/src/models/session.spec.ts
@@ -78,6 +78,32 @@ afterEach(() => {
 });
 
 describe('session model', () => {
+  describe('getSessionById', () => {
+    it('should get a session by its id', async () => {
+      const session = await getSessionById('some-session-id');
+      expect(session).toEqual({
+        ended: false,
+        exerciseState: {
+          index: 0,
+          playing: false,
+          timestamp: expect.any(String),
+        },
+        facilitator: 'some-user-id',
+        id: 'some-session-id',
+        name: 'some-name',
+        startTime: expect.any(String),
+        started: false,
+        url: 'some-url',
+        userIds: ['all'],
+      });
+    });
+
+    it('should return undefined if no session is found', async () => {
+      const session = await getSessionById('some-non-existing-session-id');
+      expect(session).toBe(undefined);
+    });
+  });
+
   describe('getSessions', () => {
     it('should get sessions', async () => {
       const sessions = await getSessions('some-non-id');

--- a/functions/src/models/session.spec.ts
+++ b/functions/src/models/session.spec.ts
@@ -25,6 +25,7 @@ import {Timestamp} from 'firebase-admin/firestore';
 import {
   addSession,
   deleteSession,
+  getSessionById,
   getSessions,
   updateExerciseState,
   updateSession,
@@ -208,8 +209,8 @@ describe('session model', () => {
 
   describe('updateSession', () => {
     it('should return updated session with started', async () => {
-      const session = await updateSession('some-session-id', {started: true});
-
+      await updateSession('some-session-id', {started: true});
+      const session = await getSessionById('some-session-id');
       expect(session).toEqual({
         id: 'some-session-id',
         name: 'some-name',
@@ -228,8 +229,8 @@ describe('session model', () => {
     });
 
     it('should return updated session with ended', async () => {
-      const session = await updateSession('some-session-id', {ended: true});
-
+      await updateSession('some-session-id', {ended: true});
+      const session = await getSessionById('some-session-id');
       expect(session).toEqual({
         id: 'some-session-id',
         name: 'some-name',
@@ -250,9 +251,10 @@ describe('session model', () => {
 
   describe('updateExerciseState', () => {
     it('should update playing', async () => {
-      const session = await updateExerciseState('some-session-id', {
+      await updateExerciseState('some-session-id', {
         playing: true,
       });
+      const session = await getSessionById('some-session-id');
 
       expect(mockRunTransaction).toHaveBeenCalledTimes(1);
       expect(mockUpdateTransaction).toHaveBeenCalledTimes(1);
@@ -275,9 +277,10 @@ describe('session model', () => {
     });
 
     it('should update index', async () => {
-      const session = await updateExerciseState('some-session-id', {
+      await updateExerciseState('some-session-id', {
         index: 2,
       });
+      const session = await getSessionById('some-session-id');
 
       expect(session).toEqual({
         id: 'some-session-id',
@@ -297,9 +300,10 @@ describe('session model', () => {
     });
 
     it('should update dailySpotlightId', async () => {
-      const session = await updateExerciseState('some-session-id', {
+      await updateExerciseState('some-session-id', {
         dailySpotlightId: 'some-user-id',
       });
+      const session = await getSessionById('some-session-id');
 
       expect(session).toEqual({
         id: 'some-session-id',

--- a/functions/src/models/session.ts
+++ b/functions/src/models/session.ts
@@ -1,0 +1,130 @@
+import 'firebase-functions';
+import {firestore} from 'firebase-admin';
+import {
+  DocumentData,
+  DocumentSnapshot,
+  Timestamp,
+} from 'firebase-admin/firestore';
+import dayjs from 'dayjs';
+
+import {
+  ExerciseState,
+  ExerciseStateData,
+  Session,
+  SessionData,
+  SessionType,
+} from '../../../shared/src/types/Session';
+import {ExerciseStateUpdate} from '../api/sessions';
+import {removeEmpty} from '../lib/utils';
+
+const defaultExerciseState = {
+  index: 0,
+  playing: false,
+  timestamp: Timestamp.now(),
+};
+
+const getData = <T>(document: DocumentSnapshot<DocumentData>) => {
+  const data = document.data();
+  return data as T;
+};
+
+const getSessionExerciseState = (
+  exerciseState: ExerciseStateData,
+): ExerciseState => ({
+  ...exerciseState,
+  timestamp: exerciseState.timestamp.toDate().toISOString(),
+});
+
+const getSession = (session: SessionData): Session => ({
+  ...session,
+  exerciseState: getSessionExerciseState(session.exerciseState),
+  startTime: session.startTime.toDate().toISOString(),
+});
+
+const SESSIONS_COLLECTION = 'sessions';
+
+export const getSessionById = async (id: Session['id']) => {
+  const sessionDoc = await firestore()
+    .collection(SESSIONS_COLLECTION)
+    .doc(id)
+    .get();
+
+  return getSession(getData<SessionData>(sessionDoc));
+};
+
+export const getSessions = async () => {
+  const sessionsCollection = firestore().collection(SESSIONS_COLLECTION);
+  const snapshot = await sessionsCollection
+    .where('ended', '==', false)
+    .where(
+      'startTime',
+      '>',
+      Timestamp.fromDate(
+        dayjs(Timestamp.now().toDate()).subtract(30, 'minute').toDate(),
+      ),
+    )
+    .where('type', '!=', SessionType.private)
+    .orderBy('startTime', 'asc')
+    .get();
+
+  return snapshot.docs.map(doc => getSession(getData<SessionData>(doc)));
+};
+
+export const addSession = async ({
+  id,
+  url,
+  contentId,
+  facilitator,
+  dailyRoomName,
+  startTime,
+  type,
+}: Omit<Session, 'exerciseState' | 'ended' | 'started'> & {
+  dailyRoomName: string;
+}) => {
+  const session = {
+    id,
+    url,
+    contentId,
+    facilitator,
+    dailyRoomName,
+    startTime: Timestamp.fromDate(new Date(startTime)),
+    exerciseState: defaultExerciseState,
+    type,
+    started: false,
+    ended: false,
+  };
+
+  const sessionDoc = firestore().collection(SESSIONS_COLLECTION).doc(id);
+  await sessionDoc.set(session);
+
+  return getSession(getData<SessionData>(await sessionDoc.get()));
+};
+
+export const deleteSession = (id: Session['id']) =>
+  firestore().collection(SESSIONS_COLLECTION).doc(id).delete();
+
+export const updateSession = async (
+  id: Session['id'],
+  data: Partial<Session>,
+) => {
+  await firestore().collection(SESSIONS_COLLECTION).doc(id).update(data);
+  return getSessionById(id);
+};
+
+export const updateExerciseState = async (
+  id: Session['id'],
+  data: ExerciseStateUpdate,
+) => {
+  const sessionDocRef = firestore().collection(SESSIONS_COLLECTION).doc(id);
+  await firestore().runTransaction(async transaction => {
+    const session = getData<SessionData>(await transaction.get(sessionDocRef));
+    const exerciseState = removeEmpty({
+      ...session.exerciseState,
+      ...data,
+      timestamp: Timestamp.now(),
+    });
+    await transaction.update(sessionDocRef, {exerciseState});
+  });
+
+  return getSessionById(id);
+};

--- a/functions/src/models/session.ts
+++ b/functions/src/models/session.ts
@@ -78,6 +78,7 @@ export const addSession = async ({
   dailyRoomName,
   startTime,
   type,
+  link,
 }: Omit<Session, 'exerciseState' | 'ended' | 'started'> & {
   dailyRoomName: string;
 }) => {
@@ -90,6 +91,7 @@ export const addSession = async ({
     startTime: Timestamp.fromDate(new Date(startTime)),
     exerciseState: defaultExerciseState,
     type,
+    link,
     started: false,
     ended: false,
   };

--- a/functions/src/models/session.ts
+++ b/functions/src/models/session.ts
@@ -49,6 +49,10 @@ export const getSessionById = async (id: Session['id']) => {
     .doc(id)
     .get();
 
+  if (!sessionDoc.exists) {
+    return;
+  }
+
   return getSession(getData<SessionData>(sessionDoc));
 };
 

--- a/functions/src/models/session.ts
+++ b/functions/src/models/session.ts
@@ -12,6 +12,7 @@ import {
   ExerciseStateData,
   Session,
   SessionData,
+  SessionType,
 } from '../../../shared/src/types/Session';
 import {ExerciseStateUpdate} from '../api/sessions';
 import {removeEmpty} from '../lib/utils';
@@ -78,8 +79,7 @@ export const addSession = async ({
   startTime,
   type,
   link,
-  userIds,
-}: Omit<Session, 'exerciseState' | 'ended' | 'started'> & {
+}: Omit<Session, 'exerciseState' | 'ended' | 'started' | 'userIds'> & {
   dailyRoomName: string;
 }) => {
   const session = {
@@ -92,7 +92,7 @@ export const addSession = async ({
     exerciseState: defaultExerciseState,
     type,
     link,
-    userIds,
+    userIds: type === SessionType.private ? [facilitator] : ['all'],
     started: false,
     ended: false,
   };
@@ -116,7 +116,7 @@ export const updateSession = async (
 
 export const updateExerciseState = async (
   id: Session['id'],
-  data: ExerciseStateUpdate,
+  data: Partial<ExerciseStateUpdate>,
 ) => {
   const sessionDocRef = firestore().collection(SESSIONS_COLLECTION).doc(id);
   await firestore().runTransaction(async transaction => {

--- a/functions/src/models/session.ts
+++ b/functions/src/models/session.ts
@@ -12,7 +12,6 @@ import {
   ExerciseStateData,
   Session,
   SessionData,
-  SessionType,
 } from '../../../shared/src/types/Session';
 import {ExerciseStateUpdate} from '../api/sessions';
 import {removeEmpty} from '../lib/utils';
@@ -52,7 +51,7 @@ export const getSessionById = async (id: Session['id']) => {
   return getSession(getData<SessionData>(sessionDoc));
 };
 
-export const getSessions = async () => {
+export const getSessions = async (userId: string) => {
   const sessionsCollection = firestore().collection(SESSIONS_COLLECTION);
   const snapshot = await sessionsCollection
     .where('ended', '==', false)
@@ -63,7 +62,7 @@ export const getSessions = async () => {
         dayjs(Timestamp.now().toDate()).subtract(30, 'minute').toDate(),
       ),
     )
-    .where('type', '!=', SessionType.private)
+    .where('userIds', 'array-contains-any', ['all', userId])
     .orderBy('startTime', 'asc')
     .get();
 
@@ -79,6 +78,7 @@ export const addSession = async ({
   startTime,
   type,
   link,
+  userIds,
 }: Omit<Session, 'exerciseState' | 'ended' | 'started'> & {
   dailyRoomName: string;
 }) => {
@@ -92,6 +92,7 @@ export const addSession = async ({
     exerciseState: defaultExerciseState,
     type,
     link,
+    userIds,
     started: false,
     ended: false,
   };

--- a/functions/src/models/session.ts
+++ b/functions/src/models/session.ts
@@ -111,7 +111,6 @@ export const updateSession = async (
   data: Partial<Session>,
 ) => {
   await firestore().collection(SESSIONS_COLLECTION).doc(id).update(data);
-  return getSessionById(id);
 };
 
 export const updateExerciseState = async (
@@ -128,6 +127,4 @@ export const updateExerciseState = async (
     });
     await transaction.update(sessionDocRef, {exerciseState});
   });
-
-  return getSessionById(id);
 };

--- a/shared/src/types/Session.ts
+++ b/shared/src/types/Session.ts
@@ -1,9 +1,8 @@
 import type {Timestamp} from 'firebase-admin/firestore';
 
 export enum SessionType {
-  private = 'private',
   public = 'public',
-  async = 'async',
+  private = 'private',
 }
 
 // Input to DB

--- a/shared/src/types/Session.ts
+++ b/shared/src/types/Session.ts
@@ -39,7 +39,7 @@ export type Session = {
   startTime: string;
   started: boolean;
   ended: boolean;
-  type: Record<SessionType, string>;
+  type: SessionType;
 };
 
 export type DailyUserData = {

--- a/shared/src/types/Session.ts
+++ b/shared/src/types/Session.ts
@@ -39,6 +39,7 @@ export type Session = {
   started: boolean;
   ended: boolean;
   type: SessionType;
+  userIds: string[];
 };
 
 export type DailyUserData = {

--- a/shared/src/types/Session.ts
+++ b/shared/src/types/Session.ts
@@ -1,5 +1,11 @@
 import type {Timestamp} from 'firebase-admin/firestore';
 
+export enum SessionType {
+  private = 'private',
+  public = 'public',
+  async = 'async',
+}
+
 // Input to DB
 export type ExerciseStateInput = Omit<ExerciseState, 'timestamp'> & {
   timestamp: Timestamp;
@@ -33,6 +39,7 @@ export type Session = {
   startTime: string;
   started: boolean;
   ended: boolean;
+  type: Record<SessionType, string>;
 };
 
 export type DailyUserData = {


### PR DESCRIPTION
Issue: https://www.notion.so/29k/Closed-BETA-0055aabd797b40c7b390b7cea4eba658#8f849201312a4784bf669096e250b810

### Description of the Change

- Introduces a `type` filed into `sessions`, and a step on session creation to choose who you'd be doing the session with. (aka session types)
- Moves sessions firestore operations to a model layer

#### Screenshots

<img src="https://user-images.githubusercontent.com/7523828/196411666-e230a9cd-45cb-4c63-a36d-40e709780e82.png" width=300 />



### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Go through the create session flow and verify that only public session types show up for now and that your session got the `type` field  on the database with the correct value.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
