### PR TITLE
New try to remove ugly video frame on iPhone 13 mini

### DIFF
--- a/client/src/routes/Session/components/VideoBase/VideoBase.tsx
+++ b/client/src/routes/Session/components/VideoBase/VideoBase.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import styled from 'styled-components/native';
 import RNVideo, {VideoProperties} from 'react-native-video';
 import {Platform} from 'react-native';
+import {COLORS} from '../../../../../../shared/src/constants/colors';
 
 const StyledVideo = styled(RNVideo)({
   flex: 1,
   shadowOpacity: 1, // Removes ugly frame on iPhone 13 mini (found in thread: https://github.com/react-native-video/react-native-video/issues/1638)
-  shadowColor: 'transparent', // Removes ugly frame on iPhone 13 mini (found in thread: https://github.com/react-native-video/react-native-video/issues/1638)
+  shadowColor: COLORS.WHITE_TRANSPARENT_01, // Removes ugly frame on iPhone 13 mini (found in thread: https://github.com/react-native-video/react-native-video/issues/1638)
 });
 
 const getSilentSwitchSetting = () =>

--- a/shared/src/constants/colors.ts
+++ b/shared/src/constants/colors.ts
@@ -24,4 +24,5 @@ export const COLORS = {
   BLACK_TRANSPARENT: 'rgba(0, 0, 0, 0.5)',
   BLACK_TRANSPARENT_30: 'rgba(46, 46, 46, 0.3)',
   WHITE_TRANSPARENT: 'rgba(255, 255, 255, 0.15)',
+  WHITE_TRANSPARENT_01: 'rgba(255, 255, 255, 0.01)',
 };


### PR DESCRIPTION
Issue: Ugly border on video on iPhone 13 mini ios15. [More details in Notion](https://www.notion.so/29k/Closed-BETA-0055aabd797b40c7b390b7cea4eba658#979b6e9486764b6cbdd1084bb5441ea3)

Adds an rgba shadowColor. This can be tested on physical device (Marias) when it's out.