### PR TITLE
Intuitive time display

### DIFF
--- a/client/src/routes/Session/components/Counter/Counter.tsx
+++ b/client/src/routes/Session/components/Counter/Counter.tsx
@@ -51,10 +51,7 @@ const Counter: React.FC<CounterProps> = ({startTime, starting = false}) => {
     }
 
     if (diff.hours() > 0) {
-      return t('counterValue.inHours', {
-        hours: diff.hours(),
-        minutes: diff.minutes(),
-      });
+      return `${t('today')}, ${startTime.format('HH:mm')}`;
     }
 
     return t('counterValue.inMinutes', {

--- a/client/src/routes/Session/components/Counter/Counter.tsx
+++ b/client/src/routes/Session/components/Counter/Counter.tsx
@@ -47,7 +47,7 @@ const Counter: React.FC<CounterProps> = ({startTime, starting = false}) => {
     const diff = dayjs.duration(startTime.diff(now));
 
     if (diff.days() > 0) {
-      return startTime.format('dddd, D MMM HH:mm');
+      return startTime.format('ddd, D MMM HH:mm');
     }
 
     if (diff.hours() > 0) {

--- a/content/src/ui/Component.Counter.json
+++ b/content/src/ui/Component.Counter.json
@@ -4,23 +4,26 @@
       "shortly": "Shortly",
       "now": "Now",
       "inHours": "{{hours}}h {{minutes}}m",
-      "inMinutes": "{{minutes}}m {{seconds}}s"
-    }
+      "inMinutes": "in {{minutes}}m {{seconds}}s"
+    },
+    "today": "Today"
   },
   "sv": {
     "counterValue": {
       "shortly": "Strax",
       "now": "Nu",
       "inHours": "{{hours}}h {{minutes}}m",
-      "inMinutes": "{{minutes}}m {{seconds}}s"
-    }
+      "inMinutes": "om {{minutes}}m {{seconds}}s"
+    },
+    "today": "idag"
   },
   "pt": {
     "counterValue": {
       "shortly": "Shortly",
       "now": "Now",
       "inHours": "{{hours}}h {{minutes}}m",
-      "inMinutes": "{{minutes}}m {{seconds}}s"
-    }
+      "inMinutes": "in {{minutes}}m {{seconds}}s"
+    },
+    "today": "hoje"
   }
 }


### PR DESCRIPTION
Issue: [More intuitive display of time and countdown](https://www.notion.so/29k/Closed-BETA-0055aabd797b40c7b390b7cea4eba658#058b97399eed403490b64a659186e227)

### Description of the Change
- Start count down on last hour
- Prefix start time with 'Today'
- Shorten weekday to allow more spacing

#### Screenshots

<!-- If client change - add screenshots for both platforms -->
| Before | After |
|-|-|
| <img width="564" alt="image" src="https://user-images.githubusercontent.com/9316860/197521581-e4b83254-d85a-41ac-9519-1dc11dcf7220.png"> | <img width="564" alt="image" src="https://user-images.githubusercontent.com/9316860/197522839-10ae6d3b-2e6a-48af-9880-15acd2e13b1e.png"> |
