### PR TITLE
Add createdAt and updatedAt to sessions

### DIFF
--- a/functions/src/models/session.spec.ts
+++ b/functions/src/models/session.spec.ts
@@ -47,6 +47,8 @@ const sessions = [
     started: false,
     ended: false,
     userIds: ['all'],
+    createdAt: Timestamp.now(),
+    updatedAt: Timestamp.now(),
   },
   {
     id: 'some-other-session-id',
@@ -62,6 +64,8 @@ const sessions = [
     started: false,
     ended: false,
     userIds: ['all'],
+    createdAt: Timestamp.now(),
+    updatedAt: Timestamp.now(),
   },
 ];
 
@@ -95,6 +99,8 @@ describe('session model', () => {
         started: false,
         url: 'some-url',
         userIds: ['all'],
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
       });
     });
 
@@ -122,6 +128,8 @@ describe('session model', () => {
           started: false,
           url: 'some-url',
           userIds: ['all'],
+          createdAt: expect.any(String),
+          updatedAt: expect.any(String),
         },
         {
           ended: false,
@@ -137,6 +145,8 @@ describe('session model', () => {
           started: false,
           url: 'some-other-url',
           userIds: ['all'],
+          createdAt: expect.any(String),
+          updatedAt: expect.any(String),
         },
       ]);
     });
@@ -199,6 +209,8 @@ describe('session model', () => {
         type: 'public',
         url: 'daily-url',
         userIds: ['all'],
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
       });
     });
 
@@ -233,6 +245,8 @@ describe('session model', () => {
         type: 'private',
         url: 'daily-url',
         userIds: ['some-user-id'],
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
       });
     });
   });
@@ -255,6 +269,8 @@ describe('session model', () => {
         started: true,
         ended: false,
         userIds: ['all'],
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
       });
     });
 
@@ -275,6 +291,8 @@ describe('session model', () => {
         started: false,
         ended: true,
         userIds: ['all'],
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
       });
     });
   });
@@ -303,6 +321,8 @@ describe('session model', () => {
         started: false,
         url: 'some-url',
         userIds: ['all'],
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
       });
     });
 
@@ -326,6 +346,8 @@ describe('session model', () => {
         started: false,
         ended: false,
         userIds: ['all'],
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
       });
     });
 
@@ -350,6 +372,8 @@ describe('session model', () => {
         started: false,
         ended: false,
         userIds: ['all'],
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
       });
     });
   });

--- a/shared/src/types/Session.ts
+++ b/shared/src/types/Session.ts
@@ -10,9 +10,11 @@ export type ExerciseStateInput = Omit<ExerciseState, 'timestamp'> & {
   timestamp: Timestamp;
 };
 
-export type SessionInput = Omit<Omit<Session, 'exerciseState'>, 'startTime'> & {
+export type SessionInput = Omit<Session, 'exerciseState' | 'startTime'> & {
   exerciseState: ExerciseStateInput;
   startTime: Timestamp;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
 };
 
 // Data stored in DB
@@ -41,6 +43,8 @@ export type Session = {
   ended: boolean;
   type: SessionType;
   userIds: string[];
+  createdAt: string;
+  updatedAt: string;
 };
 
 export type DailyUserData = {


### PR DESCRIPTION
Issue: https://www.notion.so/29k/Closed-BETA-0055aabd797b40c7b390b7cea4eba658#b730eba94f1b44619183dd2f2d898c6e


### Description of the Change

Sessions now have `createdAt` and `updatedAt` fields.

