### PR TITLE
Markdown code styles

### DIFF
--- a/client/src/common/components/Icons/Info/Info.tsx
+++ b/client/src/common/components/Icons/Info/Info.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {Path} from 'react-native-svg';
+import {IconType} from '..';
+import {COLORS} from '../../../../../../shared/src/constants/colors';
+import Icon from '../Icon';
+
+export const InfoIcon: IconType = ({fill = COLORS.BLACK}) => (
+  <Icon>
+    <Path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M14.123 18.956v-4.717a.85.85 0 1 1 1.7 0v4.716a.85.85 0 0 1-1.7 0ZM14.123 11.027v-.036a.85.85 0 0 1 1.7 0v.036a.85.85 0 1 1-1.7 0Z"
+      fill={fill}
+    />
+    <Path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M14.93 23.062a7.922 7.922 0 1 0 0-15.844 7.922 7.922 0 0 0 0 15.844Zm0 1.7a9.622 9.622 0 0 0 9.622-9.622 9.622 9.622 0 0 0-9.623-9.622 9.622 9.622 0 1 0 0 19.244Z"
+      fill={fill}
+    />
+  </Icon>
+);

--- a/client/src/common/components/Icons/index.ts
+++ b/client/src/common/components/Icons/index.ts
@@ -21,6 +21,7 @@ export * from './ForwardCircle/ForwardCircle';
 export * from './HangUp/HangUp';
 export * from './Home/Home';
 export * from './HomeFill/HomeFill';
+export * from './Info/Info';
 export * from './Logo/Logo';
 export * from './Microphone/Microphone';
 export * from './MicrophoneOff/MicrophoneOff';

--- a/client/src/common/components/Typography/Markdown/rules.tsx
+++ b/client/src/common/components/Typography/Markdown/rules.tsx
@@ -1,9 +1,19 @@
 import React, {Fragment} from 'react';
 import {View} from 'react-native';
 import {RenderRules} from 'react-native-markdown-display';
+import styled from 'styled-components/native';
+import {COLORS} from '../../../../../../shared/src/constants/colors';
+import {SPACINGS} from '../../../constants/spacings';
+import {InfoIcon} from '../../Icons';
 
 import {Spacer16} from '../../Spacers/Spacer';
 
+const IconWrapper = styled.View({
+  width: 21,
+  height: 21,
+  marginRight: 2,
+  marginLeft: -SPACINGS.FOUR,
+});
 const rules: RenderRules = {
   heading1: (node, children) => (
     <Fragment key={node.key}>
@@ -32,6 +42,17 @@ const rules: RenderRules = {
   paragraph: (node, children, parent, styles) => (
     <Fragment key={node.key}>
       <View style={styles.paragraph}>{children}</View>
+      <Spacer16 />
+    </Fragment>
+  ),
+  code_inline: (node, children, parent, styles) => (
+    <Fragment key={node.key}>
+      <View style={styles.code_inline}>
+        <IconWrapper>
+          <InfoIcon fill={COLORS.PRIMARY} />
+        </IconWrapper>
+        {children}
+      </View>
       <Spacer16 />
     </Fragment>
   ),

--- a/client/src/common/components/Typography/Markdown/rules.tsx
+++ b/client/src/common/components/Typography/Markdown/rules.tsx
@@ -7,6 +7,7 @@ import {SPACINGS} from '../../../constants/spacings';
 import {InfoIcon} from '../../Icons';
 
 import {Spacer16} from '../../Spacers/Spacer';
+import {Body16} from '../Body/Body';
 
 const IconWrapper = styled.View({
   width: 21,
@@ -45,13 +46,14 @@ const rules: RenderRules = {
       <Spacer16 />
     </Fragment>
   ),
+
   code_inline: (node, children, parent, styles) => (
     <Fragment key={node.key}>
       <View style={styles.code_inline}>
         <IconWrapper>
           <InfoIcon fill={COLORS.PRIMARY} />
         </IconWrapper>
-        {children}
+        <Body16 style={styles.code_inline_text}>{node.content}</Body16>
       </View>
       <Spacer16 />
     </Fragment>

--- a/client/src/common/components/Typography/Markdown/styles.ts
+++ b/client/src/common/components/Typography/Markdown/styles.ts
@@ -42,6 +42,13 @@ const styles = StyleSheet.create({
     marginBottom: 25,
     backgroundColor: COLORS.GREYDARK,
   },
+  code_inline: {
+    ...baseStyles.Body16,
+    padding: 0,
+    borderWidth: 0,
+    backgroundColor: 'transparent',
+    flexDirection: 'row',
+  },
 });
 
 export default styles;

--- a/client/src/common/components/Typography/Markdown/styles.ts
+++ b/client/src/common/components/Typography/Markdown/styles.ts
@@ -43,11 +43,14 @@ const styles = StyleSheet.create({
     backgroundColor: COLORS.GREYDARK,
   },
   code_inline: {
-    ...baseStyles.Body16,
     padding: 0,
     borderWidth: 0,
+    borderRadius: 0,
     backgroundColor: 'transparent',
     flexDirection: 'row',
+  },
+  code_inline_text: {
+    flexShrink: 1,
   },
 });
 

--- a/content/src/exercises/ea0b48c1-745e-418d-93e7-2d8a6cd72898.json
+++ b/content/src/exercises/ea0b48c1-745e-418d-93e7-2d8a6cd72898.json
@@ -130,7 +130,7 @@
       },
       "hostNotes": [
         {
-          "text": "> Start the session when you're ready to go."
+          "text": "Hej och hå.\n\n`Start the session when you're ready to go.`\n\nJogga på och så."
         }
       ]
     },

--- a/content/src/exercises/ea0b48c1-745e-418d-93e7-2d8a6cd72898.json
+++ b/content/src/exercises/ea0b48c1-745e-418d-93e7-2d8a6cd72898.json
@@ -130,7 +130,7 @@
       },
       "hostNotes": [
         {
-          "text": "Hej och hå.\n\n`Start the session when you're ready to go.`\n\nJogga på och så."
+          "text": "`Start the session when you're ready to go.`"
         }
       ]
     },


### PR DESCRIPTION
Issue: There is no way to distinguish what hosts should SAY and DO. [Task in notion](https://www.notion.so/29k/Closed-BETA-0055aabd797b40c7b390b7cea4eba658#2852e3bc765b4bbbb3a8b4a8adffb956)

### Description of the Change

This change makes use of the markdown `code_inline` to allow content creators to highlight information that should be done rather than said.

#### Screenshots

<!-- If client change - add screenshots for both platforms -->
| Before | After |
|-|-|
| <img width="447" alt="image" src="https://user-images.githubusercontent.com/9316860/197722794-40cb46cc-bc2a-4712-a214-3cbf6b9c68fa.png"> | <img width="564" alt="image" src="https://user-images.githubusercontent.com/9316860/197723293-81a0d6fb-b90b-41c3-bb36-2baf3807a853.png"> |
