### PR TITLE
Propagate slack errors to sentry

### DIFF
--- a/functions/src/lib/slack.spec.ts
+++ b/functions/src/lib/slack.spec.ts
@@ -76,14 +76,6 @@ describe('slack', () => {
         channel: '#some-channel',
       });
     });
-
-    it('should be allowed to fail', async () => {
-      mockPostMessage.mockRejectedValueOnce('error');
-
-      await sendPublicHostRequestMessage('some-user-id', 'some@email.com');
-
-      expect(mockPostMessage).toHaveBeenCalledTimes(1);
-    });
   });
 
   describe('updatePublicHostRequestMessage', () => {
@@ -133,18 +125,5 @@ describe('slack', () => {
         ts: 'some-ts',
       });
     });
-  });
-
-  it('should be allowed to fail', async () => {
-    mockUpdate.mockRejectedValueOnce('error');
-
-    await updatePublicHostRequestMessage(
-      'some-channel-id',
-      'some-ts',
-      'some@email.com',
-      123456,
-    );
-
-    expect(mockUpdate).toHaveBeenCalledTimes(1);
   });
 });

--- a/functions/src/lib/slack.ts
+++ b/functions/src/lib/slack.ts
@@ -108,17 +108,13 @@ export const sendPublicHostRequestMessage = async (
   email: string,
 ) => {
   if (SLACK_PUBLIC_HOST_REQUESTS_CHANNEL) {
-    try {
-      const slackClient = createSlackClient();
+    const slackClient = createSlackClient();
 
-      await slackClient.chat.postMessage({
-        blocks: createRequestBlocks(userId, email),
-        username: SLACK_BOT_NAME,
-        channel: SLACK_PUBLIC_HOST_REQUESTS_CHANNEL,
-      });
-    } catch (error) {
-      console.error('Error sending slack request', error);
-    }
+    await slackClient.chat.postMessage({
+      blocks: createRequestBlocks(userId, email),
+      username: SLACK_BOT_NAME,
+      channel: SLACK_PUBLIC_HOST_REQUESTS_CHANNEL,
+    });
   }
 };
 
@@ -128,15 +124,11 @@ export const updatePublicHostRequestMessage = async (
   email: string,
   verificationCode?: number,
 ) => {
-  try {
-    const slackClient = createSlackClient();
+  const slackClient = createSlackClient();
 
-    await slackClient.chat.update({
-      blocks: createResponseBlocks(email, verificationCode),
-      channel: channelId,
-      ts,
-    });
-  } catch (error) {
-    console.error('Error updating slack message', error);
-  }
+  await slackClient.chat.update({
+    blocks: createResponseBlocks(email, verificationCode),
+    channel: channelId,
+    ts,
+  });
 };

--- a/functions/src/slack/slack/index.ts
+++ b/functions/src/slack/slack/index.ts
@@ -8,8 +8,8 @@ slackRouter.post('/', async ctx => {
     await slackHandler(ctx.req.body?.payload as string);
     ctx.status = 200;
   } catch (error) {
-    console.error('Error handling slack action', error);
     ctx.status = 500;
+    throw error;
   }
 });
 


### PR DESCRIPTION
If we catch errors we don't see them in sentry, let Koa handle it an propagate to Sentry