### PR TITLE
Correct link in host request slack message

### DIFF
--- a/functions/src/lib/slack.spec.ts
+++ b/functions/src/lib/slack.spec.ts
@@ -108,7 +108,7 @@ describe('slack', () => {
             type: 'section',
             text: {
               type: 'mrkdwn',
-              text: '*Accepted <mailto:some@email.com?body=123456%7Csome%40email.com%7Chttp%3A%2F%2Fsome.deep%2Fverification%2Flink> as public host, please send code `123456` http://some.deep/verification/link to the user.*',
+              text: '*Accepted <mailto:some@email.com?body=123456%20-%20http%3A%2F%2Fsome.deep%2Fverification%2Flink|some@email.com> as public host, please send code `123456` http://some.deep/verification/link to the user.*',
             },
           },
         ]),

--- a/functions/src/lib/slack.ts
+++ b/functions/src/lib/slack.ts
@@ -85,8 +85,8 @@ const createResponseBlocks = (
       type: 'mrkdwn',
       text: verificationCode
         ? `*Accepted <mailto:${email}?body=${encodeURIComponent(
-            `${verificationCode}|${email}|${link}`,
-          )}> as public host, please send code \`${verificationCode}\` ${link} to the user.*`
+            `${verificationCode} - ${link}`,
+          )}|${email}> as public host, please send code \`${verificationCode}\` ${link} to the user.*`
         : `*Declined ${email} as public host*`,
     },
   },


### PR DESCRIPTION
Fixes this 
<img width="600" alt="image" src="https://user-images.githubusercontent.com/474066/198296826-997bb966-22db-489f-98dc-ad27abcc792d.png">
