### PR TITLE
Draft: Session notification component

### DIFF
--- a/client/src/routes/Session/components/Participants/Participants.tsx
+++ b/client/src/routes/Session/components/Participants/Participants.tsx
@@ -5,6 +5,8 @@ import styled from 'styled-components/native';
 import {curry} from 'ramda';
 
 import Participant from './Participant';
+import SessionNotifications from '../SessionNotifications';
+import {SPACINGS} from '../../../../common/constants/spacings';
 
 const VIDEO_WIDTH_PERCENTAGE = 0.4;
 
@@ -15,6 +17,17 @@ const ParticipantsWrapper = styled.View({
 const VideoView = styled.View<{width: number}>(props => ({
   width: props.width,
 }));
+
+const Notifications = styled(SessionNotifications)({
+  position: 'absolute',
+  left: SPACINGS.EIGHT,
+  right: SPACINGS.EIGHT,
+  top: SPACINGS.EIGHT,
+  bottom: SPACINGS.EIGHT,
+  overflow: 'hidden',
+  alignItems: 'flex-end',
+  justifyContent: 'flex-end',
+});
 
 type ParticipantsProps = {
   participants: Array<DailyParticipant>;
@@ -47,6 +60,7 @@ const Participants: React.FC<ParticipantsProps> = ({participants}) => {
         )}
         scrollEnabled={participants.length > 2}
       />
+      <Notifications />
     </ParticipantsWrapper>
   );
 };

--- a/client/src/routes/Session/components/SessionNotifications.tsx
+++ b/client/src/routes/Session/components/SessionNotifications.tsx
@@ -1,0 +1,90 @@
+import React, {useCallback, useContext, useEffect, useState} from 'react';
+import {DailyEventObject} from '@daily-co/react-native-daily-js';
+import Animated, {FadeInDown, FadeOut} from 'react-native-reanimated';
+import {Body16} from '../../../common/components/Typography/Body/Body';
+import {DailyContext} from '../DailyProvider';
+import styled from 'styled-components/native';
+import {COLORS} from '../../../../../shared/src/constants/colors';
+import {View, ViewStyle} from 'react-native';
+import {SPACINGS} from '../../../common/constants/spacings';
+import {useTranslation} from 'react-i18next';
+
+const Notification = styled(Body16)({
+  backgroundColor: COLORS.WHITE_TRANSPARENT_70,
+  padding: SPACINGS.EIGHT,
+  marginTop: SPACINGS.EIGHT,
+  borderRadius: SPACINGS.EIGHT,
+  overflow: 'hidden',
+});
+
+const SessionNotification: React.FC<{text: string}> = ({text}) => {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setVisible(false);
+    }, 3000);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, []);
+
+  if (visible) {
+    return (
+      <Animated.View entering={FadeInDown} exiting={FadeOut}>
+        <Notification>{text}</Notification>
+      </Animated.View>
+    );
+  }
+
+  return null;
+};
+
+const SessionNotifications: React.FC<{
+  style?: ViewStyle;
+}> = ({style}) => {
+  const {call} = useContext(DailyContext);
+  const {t} = useTranslation('Screen.Session');
+  const [notifications, setNotifications] = useState<string[]>([]);
+
+  const participantJoined = useCallback(
+    (user: DailyEventObject<'participant-joined'> | undefined) => {
+      setNotifications(state => [
+        ...state,
+        t('notifications.joined', {name: user?.participant.user_name}),
+      ]);
+    },
+    [t],
+  );
+
+  const participantLeft = useCallback(
+    (user: DailyEventObject<'participant-left'> | undefined) => {
+      setNotifications(state => [
+        ...state,
+        t('notifications.left', {name: user?.participant.user_name}),
+      ]);
+    },
+    [t],
+  );
+
+  useEffect(() => {
+    call?.on('participant-joined', participantJoined);
+    call?.on('participant-left', participantLeft);
+
+    return () => {
+      call?.off('participant-joined', participantJoined);
+      call?.off('participant-left', participantLeft);
+    };
+  }, [call, participantJoined, participantLeft]);
+
+  return (
+    <View style={style} pointerEvents="none">
+      {notifications.map((notification, i) => (
+        <SessionNotification text={notification} key={i} />
+      ))}
+    </View>
+  );
+};
+
+export default SessionNotifications;

--- a/content/src/ui/Screen.Session.json
+++ b/content/src/ui/Screen.Session.json
@@ -6,6 +6,10 @@
       "start": "Start",
       "next": "Next",
       "prev": "Back"
+    },
+    "notifications": {
+      "joined": "{{name}} joined",
+      "left": "{{name}} left"
     }
   },
   "sv": {
@@ -15,15 +19,13 @@
       "start": "Starta",
       "next": "Nästa",
       "prev": "Tillbaka"
+    },
+    "notifications": {
+      "joined": "{{name}} gick med",
+      "left": "{{name}} lämnade"
     }
   },
   "pt": {
-    "nameSuffix": "Você",
-    "endButton": "End Session",
-    "controls": {
-      "start": "Start",
-      "next": "Next",
-      "prev": "Back"
-    }
+    "nameSuffix": "Você"
   }
 }

--- a/shared/src/constants/colors.ts
+++ b/shared/src/constants/colors.ts
@@ -24,5 +24,6 @@ export const COLORS = {
   BLACK_TRANSPARENT: 'rgba(0, 0, 0, 0.5)',
   BLACK_TRANSPARENT_30: 'rgba(46, 46, 46, 0.3)',
   WHITE_TRANSPARENT: 'rgba(255, 255, 255, 0.15)',
+  WHITE_TRANSPARENT_70: 'rgba(255, 255, 255, 0.7)',
   WHITE_TRANSPARENT_01: 'rgba(255, 255, 255, 0.01)',
 };


### PR DESCRIPTION
Issue: There is no way of knowing when a user leaves or enters a session, they just silently end up as last participant. [notion](https://www.notion.so/29k/Closed-BETA-0055aabd797b40c7b390b7cea4eba658#915c666ef6d94975ac31cee928e5611d)

### Description of the Change

Add component that listens to daily events and briefly shows a message with witch user has joined/left. 
This implementation has couple of unsolved issues
- Message is triggered on `participant-joined `/ `participant-left`, which is triggered in the portal, leading to potential confusion of the delay of the users actual entering. Potential solution: implement wait-room?
- We do not handle queuing very well, or at all 😬
- ...more?

Current Screenshots, will be iterated
#### Screenshots

<!-- If client change - add screenshots for both platforms -->
| iOS | Android |
|-|-|
| <img width="550" alt="image" src="https://user-images.githubusercontent.com/9316860/199037164-538c5200-294e-49c4-8bee-77875d3c61c8.png"> | <img width="526" alt="image" src="https://user-images.githubusercontent.com/9316860/199037593-6538482e-4688-4ea8-afd9-3a7d52e674fc.png"> |
