### PR TITLE
Navigate to session modal after session creation

### DIFF
--- a/client/src/routes/Sessions/components/CreateSessionModal.tsx
+++ b/client/src/routes/Sessions/components/CreateSessionModal.tsx
@@ -36,6 +36,8 @@ import {Body16} from '../../../common/components/Typography/Body/Body';
 import DateTimePicker from './DateTimePicker';
 import {LANGUAGE_TAG} from '../../../lib/i18n';
 import useIsPublicHost from '../../../lib/user/hooks/useIsPublicHost';
+import {ModalStackProps} from '../../../lib/navigation/constants/routes';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 
 const Row = styled.View({
   flexDirection: 'row',
@@ -195,7 +197,8 @@ const SelectType: React.FC<StepProps> = ({
 
 const SetDateTime: React.FC<StepProps> = ({selectedExercise, selectedType}) => {
   const {t, i18n} = useTranslation('Component.CreateSessionModal');
-  const {goBack} = useNavigation();
+  const {goBack, navigate} =
+    useNavigation<NativeStackNavigationProp<ModalStackProps, 'SessionModal'>>();
   const [isLoading, setIsLoading] = useState(false);
   const [date, setDate] = useState<dayjs.Dayjs | undefined>();
   const [time, setTime] = useState<dayjs.Dayjs | undefined>();
@@ -207,7 +210,7 @@ const SetDateTime: React.FC<StepProps> = ({selectedExercise, selectedType}) => {
       const sessionDateTime = date.hour(time.hour()).minute(time.minute());
 
       setIsLoading(true);
-      await addSession({
+      const session = await addSession({
         contentId: selectedExercise,
         type: selectedType,
         startTime: sessionDateTime,
@@ -215,6 +218,7 @@ const SetDateTime: React.FC<StepProps> = ({selectedExercise, selectedType}) => {
       });
       setIsLoading(false);
       goBack();
+      navigate('SessionModal', {session});
     }
   };
 

--- a/client/src/routes/Sessions/hooks/useSessions.spec.ts
+++ b/client/src/routes/Sessions/hooks/useSessions.spec.ts
@@ -81,12 +81,12 @@ describe('useSessions', () => {
   describe('addSession', () => {
     const startTime = dayjs.utc('1994-03-08');
 
-    it('should add a session and refetch', async () => {
+    it('should resolve to a new session and trigger a refetch', async () => {
       fetchMock.mockResponseOnce(
         JSON.stringify({
           id: 'session-id',
           url: '/session-url',
-          name: 'Session Name',
+          name: 'A New Session',
         }),
         {status: 200},
       );
@@ -101,11 +101,17 @@ describe('useSessions', () => {
       });
 
       await act(async () => {
-        await result.current.addSession({
+        const session = await result.current.addSession({
           contentId: 'some-content-id',
           type: SessionType.public,
           startTime,
           language: 'en',
+        });
+
+        expect(session).toEqual({
+          id: 'session-id',
+          name: 'A New Session',
+          url: '/session-url',
         });
       });
 

--- a/client/src/routes/Sessions/hooks/useSessions.ts
+++ b/client/src/routes/Sessions/hooks/useSessions.ts
@@ -30,13 +30,14 @@ const useSessions = () => {
       startTime: dayjs.Dayjs;
       language: Session['language'];
     }) => {
-      await sessionApi.addSession({
+      const session = await sessionApi.addSession({
         contentId,
         type,
         startTime: startTime.toJSON(),
         language,
       });
       fetchSessions();
+      return session;
     },
     [fetchSessions],
   );


### PR DESCRIPTION
Issue: https://www.notion.so/29k/Closed-BETA-0055aabd797b40c7b390b7cea4eba658#82c55d2057b9407681aa35475cdb8c98


### Description of the Change

Make sure user always ends up on the session detail modal after creating a new session 

<img src="https://user-images.githubusercontent.com/7523828/199194901-a11c042c-09f1-4548-9f2b-2010222463d5.gif" width="300"/>

