### PR TITLE
Leave daily room before outro portal

### DIFF
--- a/client/src/routes/Session/Session.tsx
+++ b/client/src/routes/Session/Session.tsx
@@ -87,8 +87,13 @@ const StyledButton = styled(Button)({
 });
 
 const Session = () => {
-  const {setUserData, toggleAudio, toggleVideo, setSubscribeToAllTracks} =
-    useContext(DailyContext);
+  const {
+    setUserData,
+    toggleAudio,
+    toggleVideo,
+    setSubscribeToAllTracks,
+    leaveMeeting,
+  } = useContext(DailyContext);
   const {
     params: {sessionId},
   } = useRoute<RouteProp<SessionStackProps, 'Session'>>();
@@ -111,9 +116,10 @@ const Session = () => {
 
   useEffect(() => {
     if (session?.ended) {
+      leaveMeeting();
       navigate('OutroPortal');
     }
-  }, [session?.ended, navigate]);
+  }, [session?.ended, navigate, leaveMeeting]);
 
   useEffect(() => {
     setUserData({inPortal: false} as DailyUserData);


### PR DESCRIPTION
Issue:  🗒️  [Notion task](https://www.notion.so/29k/Closed-BETA-0055aabd797b40c7b390b7cea4eba658#ec87d786480e42d5a9d71a14ac8af53d) <!-- Link to the issue related to your PR (if any). -->

### What brings you here and how are you?



### Description of the Change

We leave the call before navigating to the outro portal.


### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Go through the call, you can join as a participant on the web through the url in the session document, when the app user/participant transitions to the outro, they should drop from the call and not be heard or seen

