### PR TITLE
LOL - fix reverese conditoin

### DIFF
--- a/client/src/routes/Session/components/SessionNotifications.tsx
+++ b/client/src/routes/Session/components/SessionNotifications.tsx
@@ -53,7 +53,7 @@ const SessionNotification: React.FC<{text: string; withProfile: boolean}> = ({
     };
   }, []);
 
-  if (!visible) {
+  if (visible) {
     return (
       <Animated.View entering={FadeInDown} exiting={FadeOut}>
         <Notification>


### PR DESCRIPTION
**Issue:** Session notification is always showing.

This PR sets it to show only for the 3 secs it should show