### PR TITLE
Handle non-joinable session on subscribe

### DIFF
--- a/client/__mocks__/@react-native-firebase/firestore.js
+++ b/client/__mocks__/@react-native-firebase/firestore.js
@@ -2,7 +2,7 @@ const mockFirestore = {
   collection: jest.fn().mockReturnValue({
     doc: jest.fn().mockReturnValue({
       onSnapshot: jest.fn(cb => {
-        cb({data: () => ({id: 'test-id'})});
+        cb({exists: true, data: () => ({id: 'test-id'})});
         return jest.fn(() => 'unsubscribe-mock');
       }),
     }),

--- a/client/__mocks__/@react-navigation/native.js
+++ b/client/__mocks__/@react-navigation/native.js
@@ -3,3 +3,4 @@ const mockNavigation = {
 };
 
 export const useNavigation = jest.fn(() => mockNavigation);
+export const useIsFocused = jest.fn();

--- a/client/src/routes/Session/ChangingRoom.tsx
+++ b/client/src/routes/Session/ChangingRoom.tsx
@@ -39,14 +39,13 @@ import {SPACINGS} from '../../common/constants/spacings';
 import TextInput from '../../common/components/Typography/TextInput/TextInput';
 import AudioIndicator from './components/Participants/AudioIdicator';
 import IconButton from '../../common/components/Buttons/IconButton/IconButton';
-import useSubscribeToSession from './hooks/useSubscribeToSession';
 import useUpdateSessionExerciseState from './hooks/useUpdateSessionExerciseState';
 import useIsSessionHost from './hooks/useIsSessionHost';
 import Screen from '../../common/components/Screen/Screen';
 import useLocalParticipant from '../../lib/daily/hooks/useLocalParticipant';
 import useUser from '../../lib/user/hooks/useUser';
 import Image from '../../common/components/Image/Image';
-import useSessions from '../Sessions/hooks/useSessions';
+import useSubscribeToSessionIfFocused from './hooks/useSusbscribeToSessionIfFocused';
 
 const Wrapper = styled.KeyboardAvoidingView.attrs({
   behavior: Platform.select({ios: 'padding', android: undefined}),
@@ -103,7 +102,6 @@ const ImageContainer = styled.View({
 const ChangingRoom = () => {
   const {t} = useTranslation('Screen.ChangingRoom');
   const [joiningMeeting, setJoiningMeeting] = useState(false);
-  const {fetchSessions} = useSessions();
 
   const {goBack, navigate} =
     useNavigation<
@@ -125,21 +123,13 @@ const ChangingRoom = () => {
     params: {sessionId: sessionId},
   } = useRoute<RouteProp<SessionStackProps, 'ChangingRoom'>>();
 
-  useSubscribeToSession(sessionId);
+  useSubscribeToSessionIfFocused(sessionId);
   const {setSpotlightParticipant} = useUpdateSessionExerciseState(sessionId);
   const isHost = useIsSessionHost();
   const isFocused = useIsFocused();
   const me = useLocalParticipant();
   const user = useUser();
   const [localUserName, setLocalUserName] = useState(user?.displayName ?? '');
-
-  useEffect(() => {
-    if (session?.ended) {
-      fetchSessions();
-      navigate('Sessions');
-      navigate('SessionUnavailableModal');
-    }
-  }, [session?.ended, navigate, fetchSessions]);
 
   useEffect(() => {
     if (isFocused && session?.url) {

--- a/client/src/routes/Session/ChangingRoom.tsx
+++ b/client/src/routes/Session/ChangingRoom.tsx
@@ -30,7 +30,11 @@ import {Body16} from '../../common/components/Typography/Body/Body';
 import {COLORS} from '../../../../shared/src/constants/colors';
 import {DailyContext} from '../../lib/daily/DailyProvider';
 import useSessionState from './state/state';
-import {SessionStackProps} from '../../lib/navigation/constants/routes';
+import {
+  ModalStackProps,
+  SessionStackProps,
+  TabNavigatorProps,
+} from '../../lib/navigation/constants/routes';
 import {SPACINGS} from '../../common/constants/spacings';
 import TextInput from '../../common/components/Typography/TextInput/TextInput';
 import AudioIndicator from './components/Participants/AudioIdicator';
@@ -42,8 +46,7 @@ import Screen from '../../common/components/Screen/Screen';
 import useLocalParticipant from '../../lib/daily/hooks/useLocalParticipant';
 import useUser from '../../lib/user/hooks/useUser';
 import Image from '../../common/components/Image/Image';
-
-type SessionNavigationProps = NativeStackNavigationProp<SessionStackProps>;
+import useSessions from '../Sessions/hooks/useSessions';
 
 const Wrapper = styled.KeyboardAvoidingView.attrs({
   behavior: Platform.select({ios: 'padding', android: undefined}),
@@ -100,8 +103,14 @@ const ImageContainer = styled.View({
 const ChangingRoom = () => {
   const {t} = useTranslation('Screen.ChangingRoom');
   const [joiningMeeting, setJoiningMeeting] = useState(false);
+  const {fetchSessions} = useSessions();
 
-  const {goBack, navigate} = useNavigation<SessionNavigationProps>();
+  const {goBack, navigate} =
+    useNavigation<
+      NativeStackNavigationProp<
+        SessionStackProps & TabNavigatorProps & ModalStackProps
+      >
+    >();
   const {
     toggleAudio,
     toggleVideo,
@@ -123,6 +132,14 @@ const ChangingRoom = () => {
   const me = useLocalParticipant();
   const user = useUser();
   const [localUserName, setLocalUserName] = useState(user?.displayName ?? '');
+
+  useEffect(() => {
+    if (session?.ended) {
+      fetchSessions();
+      navigate('Sessions');
+      navigate('SessionUnavailableModal');
+    }
+  }, [session?.ended, navigate, fetchSessions]);
 
   useEffect(() => {
     if (isFocused && session?.url) {

--- a/client/src/routes/Session/IntroPortal.tsx
+++ b/client/src/routes/Session/IntroPortal.tsx
@@ -30,7 +30,11 @@ import {
 import {Body14} from '../../common/components/Typography/Body/Body';
 import {COLORS} from '../../../../shared/src/constants/colors';
 import {HKGroteskBold} from '../../common/constants/fonts';
-import {SessionStackProps} from '../../lib/navigation/constants/routes';
+import {
+  ModalStackProps,
+  SessionStackProps,
+  TabNavigatorProps,
+} from '../../lib/navigation/constants/routes';
 import {SPACINGS} from '../../common/constants/spacings';
 import Counter from './components/Counter/Counter';
 import useSessionExercise from './hooks/useSessionExercise';
@@ -47,8 +51,7 @@ import {DailyContext} from '../../lib/daily/DailyProvider';
 import Screen from '../../common/components/Screen/Screen';
 import IconButton from '../../common/components/Buttons/IconButton/IconButton';
 import {ArrowLeftIcon} from '../../common/components/Icons';
-
-type SessionNavigationProps = NativeStackNavigationProp<SessionStackProps>;
+import useSessions from '../Sessions/hooks/useSessions';
 
 const VideoStyled = styled(VideoBase)({
   ...StyleSheet.absoluteFillObject,
@@ -111,10 +114,17 @@ const IntroPortal: React.FC = () => {
   const participantsCount = Object.keys(participants ?? {}).length;
   const isHost = useIsSessionHost();
   const {joinMeeting} = useContext(DailyContext);
-  const {navigate} = useNavigation<SessionNavigationProps>();
+  const {navigate} =
+    useNavigation<
+      NativeStackNavigationProp<
+        SessionStackProps & TabNavigatorProps & ModalStackProps
+      >
+    >();
   const isFocused = useIsFocused();
   const {setStarted} = useUpdateSession(sessionId);
   const {leaveSessionWithConfirm} = useLeaveSession();
+
+  const {fetchSessions} = useSessions();
 
   const introPortal = exercise?.introPortal;
   const textColor = exercise?.theme?.textColor;
@@ -134,6 +144,14 @@ const IntroPortal: React.FC = () => {
       },
     });
   }, [joinMeeting]);
+
+  useEffect(() => {
+    if (session?.ended) {
+      fetchSessions();
+      navigate('Sessions');
+      navigate('SessionUnavailableModal');
+    }
+  }, [session?.ended, navigate, fetchSessions]);
 
   useEffect(() => {
     if (session?.started && !endVideoRef.current) {

--- a/client/src/routes/Session/IntroPortal.tsx
+++ b/client/src/routes/Session/IntroPortal.tsx
@@ -51,7 +51,7 @@ import {DailyContext} from '../../lib/daily/DailyProvider';
 import Screen from '../../common/components/Screen/Screen';
 import IconButton from '../../common/components/Buttons/IconButton/IconButton';
 import {ArrowLeftIcon} from '../../common/components/Icons';
-import useSessions from '../Sessions/hooks/useSessions';
+import useSubscribeToSessionIfFocused from './hooks/useSusbscribeToSessionIfFocused';
 
 const VideoStyled = styled(VideoBase)({
   ...StyleSheet.absoluteFillObject,
@@ -120,11 +120,10 @@ const IntroPortal: React.FC = () => {
         SessionStackProps & TabNavigatorProps & ModalStackProps
       >
     >();
-  const isFocused = useIsFocused();
   const {setStarted} = useUpdateSession(sessionId);
   const {leaveSessionWithConfirm} = useLeaveSession();
-
-  const {fetchSessions} = useSessions();
+  const isFocused = useIsFocused();
+  useSubscribeToSessionIfFocused(sessionId);
 
   const introPortal = exercise?.introPortal;
   const textColor = exercise?.theme?.textColor;
@@ -144,14 +143,6 @@ const IntroPortal: React.FC = () => {
       },
     });
   }, [joinMeeting]);
-
-  useEffect(() => {
-    if (session?.ended) {
-      fetchSessions();
-      navigate('Sessions');
-      navigate('SessionUnavailableModal');
-    }
-  }, [session?.ended, navigate, fetchSessions]);
 
   useEffect(() => {
     if (session?.started && !endVideoRef.current) {

--- a/client/src/routes/Session/Session.tsx
+++ b/client/src/routes/Session/Session.tsx
@@ -18,7 +18,6 @@ import {DailyContext} from '../../lib/daily/DailyProvider';
 import ExerciseSlides from './components/ExerciseSlides/ExerciseSlides';
 
 import Participants from './components/Participants/Participants';
-import useSubscribeToSession from './hooks/useSubscribeToSession';
 import useSessionParticipants from './hooks/useSessionParticipants';
 import useSessionExercise from './hooks/useSessionExercise';
 import useMuteAudioListener from './hooks/useMuteAudioListener';
@@ -46,6 +45,7 @@ import HostNotes from './components/HostNotes/HostNotes';
 import Screen from '../../common/components/Screen/Screen';
 import useLocalParticipant from '../../lib/daily/hooks/useLocalParticipant';
 import useUser from '../../lib/user/hooks/useUser';
+import useSubscribeToSessionIfFocused from './hooks/useSusbscribeToSessionIfFocused';
 
 const Spotlight = styled.View({
   aspectRatio: '0.9375',
@@ -101,8 +101,7 @@ const Session = () => {
   const {navigate} =
     useNavigation<NativeStackNavigationProp<SessionStackProps>>();
   const {t} = useTranslation('Screen.Session');
-
-  useSubscribeToSession(sessionId);
+  useSubscribeToSessionIfFocused(sessionId, {exitOnEnded: false});
   useMuteAudioListener();
 
   const participants = useSessionParticipants();

--- a/client/src/routes/Session/hooks/useSubscribeToSession.spec.ts
+++ b/client/src/routes/Session/hooks/useSubscribeToSession.spec.ts
@@ -58,19 +58,4 @@ describe('useSubscribeToSession', () => {
     expect(navigation.navigate).toHaveBeenCalledWith('Sessions');
     expect(navigation.navigate).toHaveBeenCalledWith('SessionUnavailableModal');
   });
-
-  it('should handle when session has ended', () => {
-    (
-      firestore().collection('sessions').doc().onSnapshot as jest.Mock
-    ).mockImplementationOnce(cb => {
-      cb({exists: true, data: () => ({ended: true})});
-    });
-
-    const {result} = renderHook(() => useTestHook());
-    expect(result.current).toBe(null);
-
-    expect(fetchSessionsMock).toHaveBeenCalledTimes(1);
-    expect(navigation.navigate).toHaveBeenCalledWith('Sessions');
-    expect(navigation.navigate).toHaveBeenCalledWith('SessionUnavailableModal');
-  });
 });

--- a/client/src/routes/Session/hooks/useSubscribeToSession.spec.ts
+++ b/client/src/routes/Session/hooks/useSubscribeToSession.spec.ts
@@ -1,7 +1,12 @@
 import {renderHook} from '@testing-library/react-hooks';
 import firestore from '@react-native-firebase/firestore';
-
+import {useNavigation} from '@react-navigation/native';
 import useSessionState from '../state/state';
+import useSessions from '../../Sessions/hooks/useSessions';
+jest.mock('../../Sessions/hooks/useSessions');
+
+const mockUseSessions = useSessions as jest.Mock;
+
 import useSubscribeToSession from './useSubscribeToSession';
 
 afterEach(() => {
@@ -9,6 +14,10 @@ afterEach(() => {
 });
 
 describe('useSubscribeToSession', () => {
+  const fetchSessionsMock = jest.fn();
+  mockUseSessions.mockReturnValue({fetchSessions: fetchSessionsMock});
+  const navigation = useNavigation();
+
   const useTestHook = () => {
     useSubscribeToSession('session-id');
     const session = useSessionState(state => state.session);
@@ -33,5 +42,35 @@ describe('useSubscribeToSession', () => {
     const {result} = renderHook(() => useTestHook());
 
     expect(result.current).toEqual({id: 'test-id'});
+  });
+
+  it('should handle when session does not exist', () => {
+    (
+      firestore().collection('sessions').doc().onSnapshot as jest.Mock
+    ).mockImplementationOnce(cb => {
+      cb({exists: false, data: () => undefined});
+    });
+
+    const {result} = renderHook(() => useTestHook());
+    expect(result.current).toBe(null);
+
+    expect(fetchSessionsMock).toHaveBeenCalledTimes(1);
+    expect(navigation.navigate).toHaveBeenCalledWith('Sessions');
+    expect(navigation.navigate).toHaveBeenCalledWith('SessionUnavailableModal');
+  });
+
+  it('should handle when session has ended', () => {
+    (
+      firestore().collection('sessions').doc().onSnapshot as jest.Mock
+    ).mockImplementationOnce(cb => {
+      cb({exists: true, data: () => ({ended: true})});
+    });
+
+    const {result} = renderHook(() => useTestHook());
+    expect(result.current).toBe(null);
+
+    expect(fetchSessionsMock).toHaveBeenCalledTimes(1);
+    expect(navigation.navigate).toHaveBeenCalledWith('Sessions');
+    expect(navigation.navigate).toHaveBeenCalledWith('SessionUnavailableModal');
   });
 });

--- a/client/src/routes/Session/hooks/useSubscribeToSession.ts
+++ b/client/src/routes/Session/hooks/useSubscribeToSession.ts
@@ -27,7 +27,7 @@ const useSubscribeToSession = (sessionId: Session['id']) => {
       documentSnapshot => {
         const session = documentSnapshot.data() as SessionData;
 
-        if (!documentSnapshot.exists || session.ended) {
+        if (!documentSnapshot.exists) {
           fetchSessions();
           navigate('Sessions');
           navigate('SessionUnavailableModal');

--- a/client/src/routes/Session/hooks/useSubscribeToSession.ts
+++ b/client/src/routes/Session/hooks/useSubscribeToSession.ts
@@ -2,16 +2,40 @@ import {useEffect} from 'react';
 import firestore from '@react-native-firebase/firestore';
 import useSessionState from '../state/state';
 import {Session, SessionData} from '../../../../../shared/src/types/Session';
+import useSessions from '../../Sessions/hooks/useSessions';
+import {useNavigation} from '@react-navigation/native';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import {
+  ModalStackProps,
+  TabNavigatorProps,
+} from '../../../lib/navigation/constants/routes';
 
 const useSubscribeToSession = (sessionId: Session['id']) => {
   const setSessionState = useSessionState(state => state.setState);
+
+  const {navigate} =
+    useNavigation<
+      NativeStackNavigationProp<TabNavigatorProps & ModalStackProps>
+    >();
+
+  const {fetchSessions} = useSessions();
 
   useEffect(() => {
     const doc = firestore().collection('sessions').doc(sessionId);
 
     const unsubscribe = doc.onSnapshot(
-      documentSnapshot =>
-        setSessionState(documentSnapshot.data() as SessionData),
+      documentSnapshot => {
+        const session = documentSnapshot.data() as SessionData;
+
+        if (!documentSnapshot.exists || session.ended) {
+          fetchSessions();
+          navigate('Sessions');
+          navigate('SessionUnavailableModal');
+          return;
+        }
+
+        setSessionState(session);
+      },
       error =>
         console.debug(
           `Failed to subscribe to live session ${sessionId}`,
@@ -20,7 +44,7 @@ const useSubscribeToSession = (sessionId: Session['id']) => {
     );
 
     return unsubscribe;
-  }, [setSessionState, sessionId]);
+  }, [setSessionState, sessionId, navigate, fetchSessions]);
 };
 
 export default useSubscribeToSession;

--- a/client/src/routes/Session/hooks/useSubscribeToSession.ts
+++ b/client/src/routes/Session/hooks/useSubscribeToSession.ts
@@ -1,50 +1,29 @@
-import {useEffect} from 'react';
-import firestore from '@react-native-firebase/firestore';
-import useSessionState from '../state/state';
-import {Session, SessionData} from '../../../../../shared/src/types/Session';
-import useSessions from '../../Sessions/hooks/useSessions';
-import {useNavigation} from '@react-navigation/native';
-import {NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {
-  ModalStackProps,
-  TabNavigatorProps,
-} from '../../../lib/navigation/constants/routes';
+import {useCallback} from 'react';
+import firestore, {
+  FirebaseFirestoreTypes,
+} from '@react-native-firebase/firestore';
+import {Session} from '../../../../../shared/src/types/Session';
 
 const useSubscribeToSession = (sessionId: Session['id']) => {
-  const setSessionState = useSessionState(state => state.setState);
+  return useCallback(
+    (
+      onSnapshot: (
+        snapshot: FirebaseFirestoreTypes.DocumentSnapshot<FirebaseFirestoreTypes.DocumentData>,
+      ) => any,
+    ) => {
+      const doc = firestore().collection('sessions').doc(sessionId);
 
-  const {navigate} =
-    useNavigation<
-      NativeStackNavigationProp<TabNavigatorProps & ModalStackProps>
-    >();
-
-  const {fetchSessions} = useSessions();
-
-  useEffect(() => {
-    const doc = firestore().collection('sessions').doc(sessionId);
-
-    const unsubscribe = doc.onSnapshot(
-      documentSnapshot => {
-        const session = documentSnapshot.data() as SessionData;
-
-        if (!documentSnapshot.exists) {
-          fetchSessions();
-          navigate('Sessions');
-          navigate('SessionUnavailableModal');
-          return;
-        }
-
-        setSessionState(session);
-      },
-      error =>
+      const unsubscribe = doc.onSnapshot(onSnapshot, error =>
         console.debug(
           `Failed to subscribe to live session ${sessionId}`,
           error,
         ),
-    );
+      );
 
-    return unsubscribe;
-  }, [setSessionState, sessionId, navigate, fetchSessions]);
+      return unsubscribe;
+    },
+    [sessionId],
+  );
 };
 
 export default useSubscribeToSession;

--- a/client/src/routes/Session/hooks/useSusbscribeToSessionIfFocused.spec.ts
+++ b/client/src/routes/Session/hooks/useSusbscribeToSessionIfFocused.spec.ts
@@ -1,0 +1,114 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {useNavigation, useIsFocused} from '@react-navigation/native';
+import useSessionState from '../state/state';
+import useSessions from '../../Sessions/hooks/useSessions';
+jest.mock('../../Sessions/hooks/useSessions');
+jest.mock('./useSubscribeToSession');
+
+const mockUseSessions = useSessions as jest.Mock;
+const mockuseSubscribeToSession = useSubscribeToSession as jest.Mock;
+const mockUseIsFocused = useIsFocused as jest.Mock;
+
+import useSubscribeToSessionIfFocused from './useSusbscribeToSessionIfFocused';
+import useSubscribeToSession from './useSubscribeToSession';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useSubscribeToSession', () => {
+  const fetchSessionsMock = jest.fn();
+  mockUseSessions.mockReturnValue({fetchSessions: fetchSessionsMock});
+
+  const mockSubscribeToSession = jest.fn();
+  mockuseSubscribeToSession.mockReturnValue(mockSubscribeToSession);
+
+  const navigation = useNavigation();
+
+  const useTestHook = () => {
+    useSubscribeToSessionIfFocused('session-id');
+    const session = useSessionState(state => state.session);
+
+    return session;
+  };
+
+  it('should subscribe to live session document', async () => {
+    mockUseIsFocused.mockReturnValueOnce(true);
+    renderHook(() => useTestHook());
+
+    expect(mockSubscribeToSession).toHaveBeenCalledTimes(1);
+    expect(mockSubscribeToSession).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('should set live content state', () => {
+    mockUseIsFocused.mockReturnValueOnce(true);
+    mockSubscribeToSession.mockImplementation(cb =>
+      cb({data: () => ({id: 'test-id'}), exists: true}),
+    );
+
+    const {result} = renderHook(() => useTestHook());
+
+    expect(result.current).toEqual({id: 'test-id'});
+  });
+
+  it('should handle when session does not exist', () => {
+    mockUseIsFocused.mockReturnValueOnce(true);
+    mockSubscribeToSession.mockImplementationOnce(cb =>
+      cb({data: () => undefined, exists: false}),
+    );
+
+    const {result} = renderHook(() => useTestHook());
+    expect(result.current).toBe(null);
+
+    expect(fetchSessionsMock).toHaveBeenCalledTimes(1);
+    expect(navigation.navigate).toHaveBeenCalledWith('Sessions');
+    expect(navigation.navigate).toHaveBeenCalledWith('SessionUnavailableModal');
+  });
+
+  it('should handle when session has ended', () => {
+    mockUseIsFocused.mockReturnValueOnce(true);
+    mockSubscribeToSession.mockImplementationOnce(cb =>
+      cb({data: () => undefined, exists: false}),
+    );
+
+    const {result} = renderHook(() => useTestHook());
+    expect(result.current).toBe(null);
+
+    expect(fetchSessionsMock).toHaveBeenCalledTimes(1);
+    expect(navigation.navigate).toHaveBeenCalledWith('Sessions');
+    expect(navigation.navigate).toHaveBeenCalledWith('SessionUnavailableModal');
+  });
+
+  it('should unsubscribe when unfocused', () => {
+    mockUseIsFocused.mockReturnValueOnce(true);
+    mockSubscribeToSession.mockImplementationOnce(cb =>
+      cb({data: () => ({id: 'some-data'}), exists: true}),
+    );
+    const mockUnsubscribe = jest.fn();
+    mockSubscribeToSession.mockReturnValueOnce(mockUnsubscribe);
+
+    const {rerender} = renderHook(() => useTestHook());
+
+    expect(mockSubscribeToSession).toHaveBeenCalledTimes(1);
+
+    mockUseIsFocused.mockReturnValueOnce(false);
+
+    rerender();
+
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(mockSubscribeToSession).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not subscribe when unfocused', () => {
+    mockUseIsFocused.mockReturnValueOnce(false);
+    mockSubscribeToSession.mockImplementationOnce(cb =>
+      cb({data: () => ({id: 'some-data'}), exists: true}),
+    );
+    const mockUnsubscribe = jest.fn();
+    mockSubscribeToSession.mockReturnValueOnce(mockUnsubscribe);
+
+    renderHook(() => useTestHook());
+
+    expect(mockSubscribeToSession).toHaveBeenCalledTimes(0);
+  });
+});

--- a/client/src/routes/Session/hooks/useSusbscribeToSessionIfFocused.ts
+++ b/client/src/routes/Session/hooks/useSusbscribeToSessionIfFocused.ts
@@ -32,7 +32,7 @@ const useSubscribeToSessionIfFocused = (
       return subscribeToSession(documentSnapshot => {
         const session = documentSnapshot.data() as SessionData;
 
-        if (!documentSnapshot.exists || (exitOnEnded && session.ended)) {
+        if (!documentSnapshot.exists || (exitOnEnded && session?.ended)) {
           fetchSessions();
           navigate('Sessions');
           navigate('SessionUnavailableModal');

--- a/client/src/routes/Session/hooks/useSusbscribeToSessionIfFocused.ts
+++ b/client/src/routes/Session/hooks/useSusbscribeToSessionIfFocused.ts
@@ -1,0 +1,57 @@
+import {useEffect} from 'react';
+import useSessionState from '../state/state';
+import {Session, SessionData} from '../../../../../shared/src/types/Session';
+import useSessions from '../../Sessions/hooks/useSessions';
+import {useIsFocused, useNavigation} from '@react-navigation/native';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import {
+  ModalStackProps,
+  TabNavigatorProps,
+} from '../../../lib/navigation/constants/routes';
+import useSubscribeToSession from './useSubscribeToSession';
+
+type Options = {exitOnEnded?: boolean};
+
+const useSubscribeToSessionIfFocused = (
+  sessionId: Session['id'],
+  options?: Options,
+) => {
+  const {exitOnEnded = true} = options ?? {};
+  const setSessionState = useSessionState(state => state.setState);
+  const {fetchSessions} = useSessions();
+  const subscribeToSession = useSubscribeToSession(sessionId);
+  const isFocused = useIsFocused();
+
+  const {navigate} =
+    useNavigation<
+      NativeStackNavigationProp<TabNavigatorProps & ModalStackProps>
+    >();
+
+  useEffect(() => {
+    if (isFocused) {
+      return subscribeToSession(documentSnapshot => {
+        const session = documentSnapshot.data() as SessionData;
+
+        if (!documentSnapshot.exists || (exitOnEnded && session.ended)) {
+          fetchSessions();
+          navigate('Sessions');
+          navigate('SessionUnavailableModal');
+          return;
+        }
+
+        setSessionState(session);
+      });
+    }
+  }, [
+    isFocused,
+    subscribeToSession,
+    exitOnEnded,
+    fetchSessions,
+    navigate,
+    setSessionState,
+  ]);
+
+  useEffect(() => {}, [setSessionState, sessionId, navigate, fetchSessions]);
+};
+
+export default useSubscribeToSessionIfFocused;

--- a/client/src/routes/Session/hooks/useSusbscribeToSessionIfFocused.ts
+++ b/client/src/routes/Session/hooks/useSusbscribeToSessionIfFocused.ts
@@ -50,8 +50,6 @@ const useSubscribeToSessionIfFocused = (
     navigate,
     setSessionState,
   ]);
-
-  useEffect(() => {}, [setSessionState, sessionId, navigate, fetchSessions]);
 };
 
 export default useSubscribeToSessionIfFocused;

--- a/client/src/routes/Session/hooks/useUpdateSession.spec.ts
+++ b/client/src/routes/Session/hooks/useUpdateSession.spec.ts
@@ -38,23 +38,4 @@ describe('useUpdateSession', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });
-
-  describe('setEnded', () => {
-    it('should make request', async () => {
-      fetchMock.mockResponseOnce(
-        JSON.stringify({
-          data: 'some-data',
-        }),
-        {status: 200},
-      );
-
-      const {result} = renderHook(() => useTestHook());
-
-      await act(async () => {
-        await result.current.setEnded();
-      });
-
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-    });
-  });
 });

--- a/client/src/routes/Session/hooks/useUpdateSession.spec.ts
+++ b/client/src/routes/Session/hooks/useUpdateSession.spec.ts
@@ -38,4 +38,23 @@ describe('useUpdateSession', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('setEnded', () => {
+    it('should make request', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          data: 'some-data',
+        }),
+        {status: 200},
+      );
+
+      const {result} = renderHook(() => useTestHook());
+
+      await act(async () => {
+        await result.current.setEnded();
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
Issue: [Notion Task](https://www.notion.so/29k/Closed-BETA-0055aabd797b40c7b390b7cea4eba658#38b3ebbf20414cd8b07572476cf36471) ⛑️ 

### Description of the Change

Handle following cases:
- [x]  `UI state is stale, and you click the join button 30 min after the session have started or after the session have ended`
- [x]  `If the session gets deleted after you have joined`

The behaviour below applies even if the change (deletion or session being finalized) occurs *while being in a session* (already subscribed).

Handling `ended` on IntroPortal and ChangingRoom since it needs to be handle differently compared to when user is in the session (resulting in going to outro portal instead)

#### Screenshots


https://user-images.githubusercontent.com/7523828/200645438-27413a68-e38c-4e91-8791-4cab7325f145.mov

https://user-images.githubusercontent.com/7523828/200645269-53ab39dc-5beb-450b-82e0-638440bb3ecb.mov


