### PR TITLE
Update outro portal with mirror intro portal fallback

### DIFF
--- a/client/src/routes/Session/OutroPortal.tsx
+++ b/client/src/routes/Session/OutroPortal.tsx
@@ -19,6 +19,7 @@ import {useIsFocused} from '@react-navigation/native';
 import Button from '../../common/components/Buttons/Button';
 import {useTranslation} from 'react-i18next';
 import Gutters from '../../common/components/Gutters/Gutters';
+import AudioFader from './components/AudioFader/AudioFader';
 
 const VideoStyled = styled(VideoBase)({
   ...StyleSheet.absoluteFillObject,
@@ -46,6 +47,7 @@ const TopBar = styled(Gutters)({
 
 const OutroPortal: React.FC = () => {
   const finalVidRef = useRef<Video>(null);
+  const [videoLoaded, setVideoLoaded] = useState(false);
   const exercise = useSessionExercise();
   const {leaveSession} = useLeaveSession();
   const [readyToLeave, setReadyToLeave] = useState(false);
@@ -81,6 +83,7 @@ const OutroPortal: React.FC = () => {
 
   const onEndVideoLoad = () => {
     finalVidRef.current?.seek(0);
+    setVideoLoaded(true);
   };
 
   const onLoopVideoEnd = () => {
@@ -98,6 +101,15 @@ const OutroPortal: React.FC = () => {
         introPortal?.videoLoop?.source &&
         introPortal?.videoEnd?.source && (
           <>
+            {isFocused && introPortal?.videoLoop?.audio && (
+              <AudioFader
+                source={introPortal?.videoLoop.audio}
+                repeat
+                paused={!videoLoaded}
+                volume={readyToLeave ? 1 : 0}
+                duration={readyToLeave ? 20000 : 5000}
+              />
+            )}
             <VideoStyled
               ref={finalVidRef}
               onLoad={onEndVideoLoad}

--- a/client/src/routes/Session/OutroPortal.tsx
+++ b/client/src/routes/Session/OutroPortal.tsx
@@ -20,6 +20,7 @@ import Button from '../../common/components/Buttons/Button';
 import {useTranslation} from 'react-i18next';
 import Gutters from '../../common/components/Gutters/Gutters';
 import AudioFader from './components/AudioFader/AudioFader';
+import Sentry from '../../lib/sentry';
 
 const VideoStyled = styled(VideoBase)({
   ...StyleSheet.absoluteFillObject,
@@ -27,9 +28,12 @@ const VideoStyled = styled(VideoBase)({
 });
 
 const reverseVideo = (url: string) => {
-  const transformFlags = (url.match(/upload\/?(.*)\/v/) ?? [])[1];
+  const transformFlags = (url.match(/cloudinary.*\/upload\/?(.*)\/v/) ?? [])[1];
 
   if (transformFlags === undefined) {
+    Sentry.captureException(
+      new Error('Could not reverse the video - Invalid url'),
+    );
     return url;
   }
 

--- a/client/src/routes/Session/OutroPortal.tsx
+++ b/client/src/routes/Session/OutroPortal.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {StyleSheet} from 'react-native';
 import Video from 'react-native-video';
 import styled from 'styled-components/native';
@@ -14,43 +14,121 @@ import VideoBase from './components/VideoBase/VideoBase';
 import usePreventGoingBack from '../../lib/navigation/hooks/usePreventGoingBack';
 import useNavigateWithFade from '../../lib/navigation/hooks/useNavigateWithFade';
 import Screen from '../../common/components/Screen/Screen';
+import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
+import {useIsFocused} from '@react-navigation/native';
+import Button from '../../common/components/Buttons/Button';
+import {useTranslation} from 'react-i18next';
 
 const VideoStyled = styled(VideoBase)({
   ...StyleSheet.absoluteFillObject,
   flex: 1,
 });
 
+const reverseVideo = (url: string) => {
+  const transformFlags = (url.match(/upload\/?(.*)\/v/) ?? [])[1];
+
+  if (transformFlags === undefined) {
+    return url;
+  }
+
+  if (transformFlags === '') {
+    return url.replace('/upload/v', '/upload/q_auto,t_global,e_reverse/v');
+  } else {
+    return url.replace(transformFlags, `${transformFlags},e_reverse`);
+  }
+};
+
 const OutroPortal: React.FC = () => {
   const finalVidRef = useRef<Video>(null);
   const exercise = useSessionExercise();
   const {leaveSession} = useLeaveSession();
+  const [readyToLeave, setReadyToLeave] = useState(false);
+  const isFocused = useIsFocused();
+  const {t} = useTranslation('Screen.Portal');
 
   usePreventGoingBack();
   useNavigateWithFade();
 
   const outroPortal = exercise?.outroPortal;
+  const introPortal = exercise?.introPortal;
 
   useEffect(() => {
-    if (!outroPortal) {
+    if (
+      !outroPortal?.video &&
+      (!introPortal?.videoEnd || !introPortal?.videoLoop)
+    ) {
       leaveSession();
     }
-  }, [outroPortal, leaveSession]);
+  }, [
+    introPortal?.videoEnd,
+    introPortal?.videoLoop,
+    outroPortal?.video,
+    leaveSession,
+  ]);
 
-  if (!outroPortal) {
+  if (
+    outroPortal?.video?.source &&
+    (!introPortal?.videoLoop?.source || !introPortal?.videoEnd?.source)
+  ) {
     return null;
   }
+
+  const onEndVideoLoad = () => {
+    finalVidRef.current?.seek(0);
+  };
+
+  const onLoopVideoEnd = () => {
+    ReactNativeHapticFeedback.trigger('impactHeavy');
+    setReadyToLeave(true);
+  };
+
   return (
     <Screen>
       <TopSafeArea minSize={SPACINGS.SIXTEEN} />
-      <VideoStyled
-        ref={finalVidRef}
-        onLoad={() => finalVidRef.current?.seek(0)}
-        onEnd={leaveSession}
-        source={{uri: outroPortal.video?.source}}
-        resizeMode="cover"
-        poster={outroPortal.video?.preview}
-        posterResizeMode="cover"
-      />
+
+      {!outroPortal?.video?.source &&
+        introPortal?.videoLoop?.source &&
+        introPortal?.videoEnd?.source && (
+          <>
+            <VideoStyled
+              ref={finalVidRef}
+              onLoad={onEndVideoLoad}
+              paused={!readyToLeave || !isFocused}
+              source={{uri: reverseVideo(introPortal.videoLoop.source)}}
+              resizeMode="cover"
+              posterResizeMode="cover"
+              repeat={true}
+            />
+
+            {!readyToLeave && (
+              <VideoStyled
+                onEnd={onLoopVideoEnd}
+                paused={!isFocused}
+                source={{uri: reverseVideo(introPortal.videoEnd.source)}}
+                resizeMode="cover"
+                poster={introPortal.videoEnd?.preview}
+                posterResizeMode="cover"
+              />
+            )}
+          </>
+        )}
+
+      {outroPortal?.video?.source && (
+        <VideoStyled
+          ref={finalVidRef}
+          onLoad={() => finalVidRef.current?.seek(0)}
+          source={{uri: outroPortal.video.source}}
+          resizeMode="cover"
+          poster={outroPortal.video?.preview}
+          posterResizeMode="cover"
+          repeat={true}
+        />
+      )}
+      {readyToLeave && (
+        <Button small onPress={() => leaveSession()}>
+          {t('leavePortal')}
+        </Button>
+      )}
       <BottomSafeArea minSize={SPACINGS.SIXTEEN} />
     </Screen>
   );

--- a/client/src/routes/Session/OutroPortal.tsx
+++ b/client/src/routes/Session/OutroPortal.tsx
@@ -18,6 +18,7 @@ import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import {useIsFocused} from '@react-navigation/native';
 import Button from '../../common/components/Buttons/Button';
 import {useTranslation} from 'react-i18next';
+import Gutters from '../../common/components/Gutters/Gutters';
 
 const VideoStyled = styled(VideoBase)({
   ...StyleSheet.absoluteFillObject,
@@ -37,6 +38,11 @@ const reverseVideo = (url: string) => {
     return url.replace(transformFlags, `${transformFlags},e_reverse`);
   }
 };
+
+const TopBar = styled(Gutters)({
+  justifyContent: 'flex-end',
+  flexDirection: 'row',
+});
 
 const OutroPortal: React.FC = () => {
   const finalVidRef = useRef<Video>(null);
@@ -82,6 +88,8 @@ const OutroPortal: React.FC = () => {
     setReadyToLeave(true);
   };
 
+  console.log(readyToLeave);
+
   return (
     <Screen>
       <TopSafeArea minSize={SPACINGS.SIXTEEN} />
@@ -116,7 +124,10 @@ const OutroPortal: React.FC = () => {
       {outroPortal?.video?.source && (
         <VideoStyled
           ref={finalVidRef}
-          onLoad={() => finalVidRef.current?.seek(0)}
+          onLoad={() => {
+            finalVidRef.current?.seek(0);
+            onLoopVideoEnd();
+          }}
           source={{uri: outroPortal.video.source}}
           resizeMode="cover"
           poster={outroPortal.video?.preview}
@@ -125,9 +136,11 @@ const OutroPortal: React.FC = () => {
         />
       )}
       {readyToLeave && (
-        <Button small onPress={() => leaveSession()}>
-          {t('leavePortal')}
-        </Button>
+        <TopBar>
+          <Button variant="secondary" small onPress={leaveSession}>
+            {t('leavePortal')}
+          </Button>
+        </TopBar>
       )}
       <BottomSafeArea minSize={SPACINGS.SIXTEEN} />
     </Screen>

--- a/client/src/routes/Session/OutroPortal.tsx
+++ b/client/src/routes/Session/OutroPortal.tsx
@@ -38,7 +38,7 @@ const reverseVideo = (url: string) => {
   }
 
   if (transformFlags === '') {
-    return url.replace('/upload/v', '/upload/q_auto,t_global,e_reverse/v');
+    return url.replace('/upload/v', '/upload/e_reverse/v');
   } else {
     return url.replace(transformFlags, `${transformFlags},e_reverse`);
   }

--- a/client/src/routes/Session/OutroPortal.tsx
+++ b/client/src/routes/Session/OutroPortal.tsx
@@ -46,7 +46,7 @@ const TopBar = styled(Gutters)({
 });
 
 const OutroPortal: React.FC = () => {
-  const finalVidRef = useRef<Video>(null);
+  const loopingVid = useRef<Video>(null);
   const [videoLoaded, setVideoLoaded] = useState(false);
   const exercise = useSessionExercise();
   const {leaveSession} = useLeaveSession();
@@ -82,7 +82,7 @@ const OutroPortal: React.FC = () => {
   }
 
   const onEndVideoLoad = () => {
-    finalVidRef.current?.seek(0);
+    loopingVid.current?.seek(0);
     setVideoLoaded(true);
   };
 
@@ -90,8 +90,6 @@ const OutroPortal: React.FC = () => {
     ReactNativeHapticFeedback.trigger('impactHeavy');
     setReadyToLeave(true);
   };
-
-  console.log(readyToLeave);
 
   return (
     <Screen>
@@ -111,7 +109,7 @@ const OutroPortal: React.FC = () => {
               />
             )}
             <VideoStyled
-              ref={finalVidRef}
+              ref={loopingVid}
               onLoad={onEndVideoLoad}
               paused={!readyToLeave || !isFocused}
               source={{uri: reverseVideo(introPortal.videoLoop.source)}}
@@ -135,9 +133,9 @@ const OutroPortal: React.FC = () => {
 
       {outroPortal?.video?.source && (
         <VideoStyled
-          ref={finalVidRef}
+          ref={loopingVid}
           onLoad={() => {
-            finalVidRef.current?.seek(0);
+            loopingVid.current?.seek(0);
             onLoopVideoEnd();
           }}
           source={{uri: outroPortal.video.source}}

--- a/client/src/routes/Session/hooks/useLeaveSession.ts
+++ b/client/src/routes/Session/hooks/useLeaveSession.ts
@@ -7,6 +7,7 @@ import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {DailyContext} from '../../../lib/daily/DailyProvider';
 import useSessionState from '../state/state';
 import {TabNavigatorProps} from '../../../lib/navigation/constants/routes';
+import useSessions from '../../Sessions/hooks/useSessions';
 
 type ScreenNavigationProps = NativeStackNavigationProp<TabNavigatorProps>;
 
@@ -14,14 +15,16 @@ const useLeaveSession = () => {
   const {t} = useTranslation('Component.ConfirmExitSession');
   const {leaveMeeting} = useContext(DailyContext);
   const {navigate} = useNavigation<ScreenNavigationProps>();
+  const {fetchSessions} = useSessions();
 
   const resetSession = useSessionState(state => state.reset);
 
   const leaveSession = useCallback(async () => {
     await leaveMeeting();
     resetSession();
+    fetchSessions();
     navigate('Sessions');
-  }, [leaveMeeting, resetSession, navigate]);
+  }, [leaveMeeting, resetSession, navigate, fetchSessions]);
 
   const leaveSessionWithConfirm = useCallback(async () => {
     Alert.alert(t('header'), t('text'), [

--- a/content/src/exercises/095f9642-73b6-4c9a-ae9a-ea7dea7363f5.json
+++ b/content/src/exercises/095f9642-73b6-4c9a-ae9a-ea7dea7363f5.json
@@ -39,8 +39,9 @@
         "content": {
           "heading": "Pure simple love",
           "video": {
-            "source": "https://res.cloudinary.com/twentyninek/video/upload/q_auto,t_global/v1663328548/temp/audio_meditation_2_b3hwge.mp4"
-          }
+            "source": "https://res.cloudinary.com/twentyninek/video/upload/v1663328548/temp/audio_meditation_2_b3hwge.mp4"
+          },
+          "image": "https://res.cloudinary.com/twentyninek/image/upload/q_auto,t_global/v1636016815/Singles/sticky_eng_ps00eg.png"
         },
         "hostNotes": [
           {
@@ -56,7 +57,7 @@
         "content": {
           "heading": "Reflect: How did this meditation affect you?",
           "video": {
-            "source": "https://res.cloudinary.com/twentyninek/video/upload/q_auto,t_global/v1663328538/temp/1_min_eto52x.mp4"
+            "source": "https://res.cloudinary.com/twentyninek/video/upload/v1663328538/temp/1_min_eto52x.mp4"
           }
         },
         "hostNotes": [
@@ -73,7 +74,7 @@
         "content": {
           "heading": "Share: How did this meditation affect you?",
           "video": {
-            "source": "https://res.cloudinary.com/twentyninek/video/upload/q_auto,t_global/v1663328538/temp/2_min_fr9hsu.mp4"
+            "source": "https://res.cloudinary.com/twentyninek/video/upload/v1663328538/temp/2_min_fr9hsu.mp4"
           }
         },
         "hostNotes": [

--- a/content/src/exercises/94575e97-fe03-4bfd-94a6-50aaf721d47e.json
+++ b/content/src/exercises/94575e97-fe03-4bfd-94a6-50aaf721d47e.json
@@ -32,7 +32,7 @@
         "content": {
           "video": {
             "audio": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667298005/Audio/Agnes_bell_kmwzos_eznpow.mp3",
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto,t_global/v1667297532/Video/Accepting_thoughts_and_feelings_meditation_cn20lx.mp4",
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667297532/Video/Accepting_thoughts_and_feelings_meditation_cn20lx.mp4",
             "autoPlayLoop": false
           }
         }
@@ -50,7 +50,7 @@
         "content": {
           "heading": "What did you notice?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto,t_global/v1667317097/Video/1min_Accepting_thoughts_and_feelings_xdvlcn.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667317097/Video/1min_Accepting_thoughts_and_feelings_xdvlcn.mp4"
           }
         }
       },
@@ -59,7 +59,7 @@
         "content": {
           "heading": "What did you notice?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto,t_global/v1667317099/Video/2min_Accepting_thoughts_and_feelings_b9bxvx.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667317099/Video/2min_Accepting_thoughts_and_feelings_b9bxvx.mp4"
           }
         },
         "hostNotes": [
@@ -79,7 +79,7 @@
         "content": {
           "heading": "Up for a mission?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto,t_global/v1667376437/Video/mission_Accepting_thoughts_and_feelings_x7qguf.mp4",
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667376437/Video/mission_Accepting_thoughts_and_feelings_x7qguf.mp4",
             "autoPlayLoop": true
           }
         },
@@ -100,11 +100,11 @@
         }
       ],
       "videoLoop": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto,t_global/v1667376603/Video/portal1_Accepting_thoughts_and_feelings_upvkxb.mp4",
-        "audio": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto,t_global/v1667317049/Audio/portal_Accepting_thoughts_and_feelings_ynb5i9.mp3"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667376603/Video/portal1_Accepting_thoughts_and_feelings_upvkxb.mp4",
+        "audio": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667317049/Audio/portal_Accepting_thoughts_and_feelings_ynb5i9.mp3"
       },
       "videoEnd": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto,t_global/v1667317594/Video/portal2_Accepting_thoughts_and_feelings_iyqnuk.mp4"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667317594/Video/portal2_Accepting_thoughts_and_feelings_iyqnuk.mp4"
       }
     },
     "card": {
@@ -114,7 +114,7 @@
     },
     "outroPortal": {
       "video": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto,t_global/v1667376603/Video/portal1_Accepting_thoughts_and_feelings_upvkxb.mp4"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667376603/Video/portal1_Accepting_thoughts_and_feelings_upvkxb.mp4"
       }
     }
   },

--- a/content/src/exercises/ea0b48c1-745e-418d-93e7-2d8a6cd72898.json
+++ b/content/src/exercises/ea0b48c1-745e-418d-93e7-2d8a6cd72898.json
@@ -19,7 +19,7 @@
         "type": "content",
         "content": {
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto,t_global/v1665464756/Temp/Comp_8_jsv5jo.mp4",
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1665464756/Temp/Comp_8_jsv5jo.mp4",
             "description": "",
             "preview": "",
             "autoPlayLoop": true
@@ -44,7 +44,7 @@
         "content": {
           "heading": "I would like to X, but I am so Y",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto,t_global/v1665464767/Temp/Comp_4_wrr4ks.mp4",
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1665464767/Temp/Comp_4_wrr4ks.mp4",
             "autoPlayLoop": false
           }
         },
@@ -62,7 +62,7 @@
         "content": {
           "heading": "What happens when you switch from using BUT to using AND?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto,t_global/v1665464773/Temp/Comp_9_bsizws.mp4",
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1665464773/Temp/Comp_9_bsizws.mp4",
             "autoPlayLoop": false
           }
         },
@@ -80,7 +80,7 @@
         "content": {
           "heading": "What happens when you switch from BUT to using AND?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto,t_global/v1665464766/Temp/Comp_10_ababts.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1665464766/Temp/Comp_10_ababts.mp4"
           }
         },
         "hostNotes": [
@@ -126,10 +126,10 @@
     },
     "introPortal": {
       "videoLoop": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto,t_global/v1665480650/Temp/portal_no_sound_o7okas.mp4"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1665480650/Temp/portal_no_sound_o7okas.mp4"
       },
       "videoEnd": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto,t_global/v1665469668/Temp/Comp_13_1_xmcpyo.mp4"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1665469668/Temp/Comp_13_1_xmcpyo.mp4"
       },
       "hostNotes": [
         {

--- a/content/src/ui/Screen.Portal.json
+++ b/content/src/ui/Screen.Portal.json
@@ -7,7 +7,8 @@
     "counterLabel": {
       "starts": "Starting",
       "started": "Now"
-    }
+    },
+    "leavePortal": "Leave"
   },
   "sv": {
     "participants": "Vi är",


### PR DESCRIPTION
Issue: [Notion Task](https://www.notion.so/29k/Closed-BETA-0055aabd797b40c7b390b7cea4eba658#9d6e226db30c4d899844348a7864867b) ⛑️ 

### TODO

- [x] Check if the video loop sound is reversed and if it sounds good 😬  (SOUNDS SUPER COOL ACTUALLY HAHA tested on Accepting thoughts and feelings since it has video audio for the transition)

### Description of the Change

When outro portal's content isn't defined, the app will take the intro portal and play it backwards. 
As if all ends mirrors their beginnings, ouffffff 🧙 

#### Screenshots

https://user-images.githubusercontent.com/7523828/201306858-c1f9d415-3de0-4907-9ce2-2c948ebdea18.mov


https://user-images.githubusercontent.com/7523828/201307464-44b3414f-614c-4624-88a7-31337a01ea4d.mov



### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
