### PR TITLE
Fix user re-creation when app is kill switched

### DIFF
--- a/client/src/lib/apiClient/apiClient.ts
+++ b/client/src/lib/apiClient/apiClient.ts
@@ -79,13 +79,20 @@ const apiClient = async (input: string, init?: RequestInit | undefined) => {
 
   const response = await doFetch();
 
-  if (response.status === 401 || response.status === 403) {
+  /*
+    Please note that 403 Forbidden is used by kill switch to deny access to
+    the app and should not be used for user (re)authentication purposes
+  */
+
+  // 401 Unauthorized - no user detected at all
+  if (response.status === 401) {
     await recreateUser();
     return await doFetch();
   }
 
-  // TODO: Handle this with asking the user to reauthenticate if not anonymous
-  if (response.status === 403) {
+  // TODO: Handle this by asking the user to reauthenticate if not anonymous
+  // 400 Bad Request - probably have been authenticated before but now revoked
+  if (response.status === 400) {
     await recreateUser();
     return await doFetch();
   }

--- a/functions/src/api/lib/firebaseAuth.spec.ts
+++ b/functions/src/api/lib/firebaseAuth.spec.ts
@@ -71,7 +71,7 @@ describe('firebaseAuth', () => {
     expect(next).toHaveBeenCalledTimes(0);
   });
 
-  it('returns 403 when token expired', async () => {
+  it('returns 400 when token expired', async () => {
     (getAuth().verifyIdToken as jest.Mock).mockRejectedValueOnce({
       code: 'auth/id-token-expired',
     });
@@ -90,7 +90,7 @@ describe('firebaseAuth', () => {
     expect(getAuth().verifyIdToken).toHaveBeenCalledTimes(1);
 
     expect(ctx).toEqual({
-      status: 403,
+      status: 400,
       headers: {
         authorization: 'bearer some-token',
       },
@@ -99,7 +99,7 @@ describe('firebaseAuth', () => {
     expect(next).toHaveBeenCalledTimes(0);
   });
 
-  it('returns 403 when token revoked', async () => {
+  it('returns 400 when token revoked', async () => {
     (getAuth().verifyIdToken as jest.Mock).mockRejectedValueOnce({
       code: 'auth/id-token-revoked',
     });
@@ -118,7 +118,7 @@ describe('firebaseAuth', () => {
     expect(getAuth().verifyIdToken).toHaveBeenCalledTimes(1);
 
     expect(ctx).toEqual({
-      status: 403,
+      status: 400,
       headers: {
         authorization: 'bearer some-token',
       },

--- a/functions/src/api/lib/firebaseAuth.ts
+++ b/functions/src/api/lib/firebaseAuth.ts
@@ -36,7 +36,7 @@ const firebaseAuth = () => async (ctx: FirebaseAuthContext, next: Next) => {
       }
       case 'auth/id-token-expired':
       case 'auth/id-token-revoked': {
-        ctx.status = 403;
+        ctx.status = 400;
         return;
       }
 


### PR DESCRIPTION
Issue: [Issue in Notion](https://www.notion.so/29k/Closed-BETA-0055aabd797b40c7b390b7cea4eba658#0e96123ad2da486b82f59a2bc1f8e539)

This fixes an issue where users gets re-created when app is kill switched (HTTP 403 Forbidden)
