### PR TITLE
Run client tests before native version check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,14 +57,14 @@ jobs:
         working-directory: ./client
         run: yarn
 
+      - name: Run tests
+        working-directory: ./client
+        run: yarn test
+
       - name: Check if native versions needs bump
         if: inputs.skipClientVersionBumpTest != true
         working-directory: ./client
         run: yarn test:version
-
-      - name: Run tests
-        working-directory: ./client
-        run: yarn test
 
   functions:
     name: Functions


### PR DESCRIPTION
So the regular tests don't get blocked by native version check