### PR TITLE
Remove testing.app.cupcake.29k.org deep link domain

### DIFF
--- a/client/android/app/build.gradle
+++ b/client/android/app/build.gradle
@@ -279,7 +279,7 @@ android {
         }
         dev {
             applicationId 'org.twentyninek.app.cupcake.dev'
-            manifestPlaceholders.deepLinkHost = 'testing.app.cupcake.29k.org'
+            manifestPlaceholders.deepLinkHost = 'dev.app.cupcake.29k.org'
         }
     }
 }

--- a/client/ios/Supporting/Info.plist
+++ b/client/ios/Supporting/Info.plist
@@ -149,7 +149,6 @@
 		<string>https://app.cupcake.29k.org/</string>
 		<string>https://staging.app.cupcake.29k.org/</string>
 		<string>https://dev.app.cupcake.29k.org/</string>
-		<string>https://testing.app.cupcake.29k.org/</string>
 	</array>
 	<key>FirebaseDeepLinkPasteboardRetrievalEnabled</key>
 	<false/>

--- a/client/ios/dev.entitlements
+++ b/client/ios/dev.entitlements
@@ -5,7 +5,6 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:dev.app.cupcake.29k.org</string>
-		<string>applinks:testing.app.cupcake.29k.org</string>
 	</array>
 </dict>
 </plist>

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -77,5 +77,5 @@ yarn test
    ```
 4. Open links in iOS and Android simulators from the terminal:
    ```
-   npx uri-scheme open "https://testing.app.cupcake.29k.org/jksd23kjh2kjhk" --ios --android
+   npx uri-scheme open "https://dev.app.cupcake.29k.org/jksd23kjh2kjhk" --ios --android
    ```


### PR DESCRIPTION
in favour of `dev.app.cupcake.29k.org`