### PR TITLE
Reset session notification state

### DIFF
--- a/client/src/routes/Session/hooks/useLeaveSession.ts
+++ b/client/src/routes/Session/hooks/useLeaveSession.ts
@@ -8,6 +8,7 @@ import {DailyContext} from '../../../lib/daily/DailyProvider';
 import useSessionState from '../state/state';
 import {TabNavigatorProps} from '../../../lib/navigation/constants/routes';
 import useSessions from '../../Sessions/hooks/useSessions';
+import useSessionNotificationsState from '../state/sessionNotificationsState';
 
 type ScreenNavigationProps = NativeStackNavigationProp<TabNavigatorProps>;
 
@@ -18,13 +19,24 @@ const useLeaveSession = () => {
   const {fetchSessions} = useSessions();
 
   const resetSession = useSessionState(state => state.reset);
+  const resetSessionNotifications = useSessionNotificationsState(
+    state => state.reset,
+  );
 
   const leaveSession = useCallback(async () => {
     await leaveMeeting();
     resetSession();
+    resetSessionNotifications();
+
     fetchSessions();
     navigate('Sessions');
-  }, [leaveMeeting, resetSession, navigate, fetchSessions]);
+  }, [
+    leaveMeeting,
+    resetSession,
+    resetSessionNotifications,
+    navigate,
+    fetchSessions,
+  ]);
 
   const leaveSessionWithConfirm = useCallback(async () => {
     Alert.alert(t('header'), t('text'), [

--- a/client/src/routes/Session/hooks/useMuteAudioListener.ts
+++ b/client/src/routes/Session/hooks/useMuteAudioListener.ts
@@ -31,8 +31,8 @@ const useMuteAudioListener = () => {
     }
   }, [
     toggleAudio,
-    exerciseState,
-    excercise,
+    exerciseState?.playing,
+    excercise?.slide,
     addNotification,
     t,
     isSessionHost,


### PR DESCRIPTION
Issue: [session notification state](https://www.notion.so/29k/Closed-BETA-0055aabd797b40c7b390b7cea4eba658#b9bb3d34052d4561886636858872d3f9)

- Reset state when participant leaves session
- Compares 'joined at' on local and daily participant to avoid getting all current particiants in the notifications
