### PR TITLE
Prevent state race condition on host notes navigation

### DIFF
--- a/client/src/routes/Session/components/HostNotes/HostNotes.tsx
+++ b/client/src/routes/Session/components/HostNotes/HostNotes.tsx
@@ -161,8 +161,13 @@ const HostNotes: React.FC<HostNotesProps> = ({
               <Navigation>
                 <NavButton
                   onPress={() => {
+                    const newIndex = activeIndex - 1;
+                    if (newIndex < 0) {
+                      return;
+                    }
+                    setActiveIndex(newIndex);
                     listRef.current?.scrollToIndex({
-                      index: activeIndex - 1,
+                      index: newIndex,
                     });
                   }}
                   Icon={BackwardCircleIcon}
@@ -170,11 +175,16 @@ const HostNotes: React.FC<HostNotesProps> = ({
                 />
                 <Body14>{`${activeIndex + 1} / ${notes.length}`}</Body14>
                 <NavButton
-                  onPress={() =>
+                  onPress={() => {
+                    const newIndex = activeIndex + 1;
+                    if (newIndex >= notes.length) {
+                      return;
+                    }
+                    setActiveIndex(newIndex);
                     listRef.current?.scrollToIndex({
-                      index: activeIndex + 1,
-                    })
-                  }
+                      index: newIndex,
+                    });
+                  }}
                   Icon={ForwardCircleIcon}
                   disabled={activeIndex >= notes.length - 1}
                 />

--- a/client/src/routes/Session/components/HostNotes/HostNotes.tsx
+++ b/client/src/routes/Session/components/HostNotes/HostNotes.tsx
@@ -91,22 +91,21 @@ const HostNotes: React.FC<HostNotesProps> = ({
   const exercise = useSessionExercise();
   const {t} = useTranslation('Component.HostNotes');
 
-  useEffect(() => {
-    console.log('scrolling to - ', scroll.index);
-    listRef.current?.scrollToIndex({
-      animated: scroll.animated,
-      index: scroll.index,
-    });
-  }, [scroll.animated, scroll.index]);
+  useEffect(
+    () =>
+      listRef.current?.scrollToIndex({
+        animated: scroll.animated,
+        index: scroll.index,
+      }),
+    [scroll.animated, scroll.index],
+  );
 
   const calculatePageIndex = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      console.log('setting scroll - calculatePageIndex');
+    (e: NativeSyntheticEvent<NativeScrollEvent>) =>
       setScroll({
         index: Math.round(e?.nativeEvent?.contentOffset?.x / containerWidth),
         animated: true,
-      });
-    },
+      }),
     [containerWidth],
   );
 


### PR DESCRIPTION
Issue: #1095 

### Description of the Change

~Adds a `return` statement to prevent the `onPress` execution.~

Re-actively navigates to slides based on scroll state.

### Verification Process

If you try to manually press the host note navigation buttons faster than the `activeIndex` state  updates it would cause the error, now, with it being reactive to the state, the issue should not happen anymore.
