### PR TITLE
Add q_auto:eco to video cloudnary urls

### DIFF
--- a/cms/src/fields/constants.ts
+++ b/cms/src/fields/constants.ts
@@ -15,7 +15,11 @@ export const CLOUDINARY_IMAGE_CONFIG = {
 export const CLOUDINARY_VIDEO_CONFIG = {
   name: 'cloudinary',
   config: {
-    default_transformations: [],
+    default_transformations: [
+      {
+        quality: 'auto:eco',
+      },
+    ],
   },
 };
 

--- a/content/src/exercises/095f9642-73b6-4c9a-ae9a-ea7dea7363f5.json
+++ b/content/src/exercises/095f9642-73b6-4c9a-ae9a-ea7dea7363f5.json
@@ -10,11 +10,11 @@
     "introPortal": {
       "type": "video",
       "videoLoop": {
-        "source": "https://res.cloudinary.com/twentyninek/video/upload/v1663143395/temp/portal-intro_h7qccz.mp4",
-        "audio": "https://res.cloudinary.com/twentyninek/video/upload/v1664811123/temp/ocean_s3t5yy_mm2dgh.mp3"
+        "source": "https://res.cloudinary.com/twentyninek/video/upload/q_auto:eco/v1663143395/temp/portal-intro_h7qccz.mp4",
+        "audio": "https://res.cloudinary.com/twentyninek/video/upload/q_auto:eco/v1664811123/temp/ocean_s3t5yy_mm2dgh.mp3"
       },
       "videoEnd": {
-        "source": "https://res.cloudinary.com/twentyninek/video/upload/v1663147750/temp/portal-intro-end_crzjih.mp4"
+        "source": "https://res.cloudinary.com/twentyninek/video/upload/q_auto:eco/v1663147750/temp/portal-intro-end_crzjih.mp4"
       },
       "hostNotes": [
         {
@@ -39,7 +39,7 @@
         "content": {
           "heading": "Pure simple love",
           "video": {
-            "source": "https://res.cloudinary.com/twentyninek/video/upload/v1663328548/temp/audio_meditation_2_b3hwge.mp4"
+            "source": "https://res.cloudinary.com/twentyninek/video/upload/q_auto:eco/v1663328548/temp/audio_meditation_2_b3hwge.mp4"
           },
           "image": "https://res.cloudinary.com/twentyninek/image/upload/q_auto,t_global/v1636016815/Singles/sticky_eng_ps00eg.png"
         },
@@ -57,7 +57,7 @@
         "content": {
           "heading": "How did this meditation affect you?",
           "video": {
-            "source": "https://res.cloudinary.com/twentyninek/video/upload/v1663328538/temp/1_min_eto52x.mp4"
+            "source": "https://res.cloudinary.com/twentyninek/video/upload/q_auto:eco/v1663328538/temp/1_min_eto52x.mp4"
           },
           "text": "What can you bring for the rest of the day?"
         },
@@ -75,7 +75,7 @@
         "content": {
           "heading": "How did this meditation affect you?",
           "video": {
-            "source": "https://res.cloudinary.com/twentyninek/video/upload/v1663328538/temp/2_min_fr9hsu.mp4"
+            "source": "https://res.cloudinary.com/twentyninek/video/upload/q_auto:eco/v1663328538/temp/2_min_fr9hsu.mp4"
           },
           "text": "What can you bring for the rest of the day?"
         },
@@ -112,7 +112,7 @@
     "published": true,
     "outroPortal": {
       "video": {
-        "source": "https://res.cloudinary.com/twentyninek/video/upload/v1664798564/temp/portal_outro_lpm80e.mp4"
+        "source": "https://res.cloudinary.com/twentyninek/video/upload/q_auto:eco/v1664798564/temp/portal_outro_lpm80e.mp4"
       }
     }
   },
@@ -127,11 +127,11 @@
     "introPortal": {
       "type": "video",
       "videoLoop": {
-        "source": "https://res.cloudinary.com/twentyninek/video/upload/v1663143395/temp/portal-intro_h7qccz.mp4",
-        "audio": "https://res.cloudinary.com/twentyninek/video/upload/v1664811123/temp/ocean_s3t5yy_mm2dgh.mp3"
+        "source": "https://res.cloudinary.com/twentyninek/video/upload/q_auto:eco/v1663143395/temp/portal-intro_h7qccz.mp4",
+        "audio": "https://res.cloudinary.com/twentyninek/video/upload/q_auto:eco/v1664811123/temp/ocean_s3t5yy_mm2dgh.mp3"
       },
       "videoEnd": {
-        "source": "https://res.cloudinary.com/twentyninek/video/upload/v1663147750/temp/portal-intro-end_crzjih.mp4"
+        "source": "https://res.cloudinary.com/twentyninek/video/upload/q_auto:eco/v1663147750/temp/portal-intro-end_crzjih.mp4"
       },
       "hostNotes": [
         {
@@ -229,7 +229,7 @@
     "published": true,
     "outroPortal": {
       "video": {
-        "source": "https://res.cloudinary.com/twentyninek/video/upload/v1664798564/temp/portal_outro_lpm80e.mp4"
+        "source": "https://res.cloudinary.com/twentyninek/video/upload/q_auto:eco/v1664798564/temp/portal_outro_lpm80e.mp4"
       }
     }
   },

--- a/content/src/exercises/185889ec-753b-4e2c-8322-3004013e8a6e.json
+++ b/content/src/exercises/185889ec-753b-4e2c-8322-3004013e8a6e.json
@@ -14,11 +14,11 @@
         }
       ],
       "videoLoop": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043755/Video/portal1_Be_kind_to_yourself_u6lvok.mp4",
-        "audio": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043586/Audio/portal_audio_Be_kind_to_yourself_nnkrwz.mp3"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043755/Video/portal1_Be_kind_to_yourself_u6lvok.mp4",
+        "audio": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043586/Audio/portal_audio_Be_kind_to_yourself_nnkrwz.mp3"
       },
       "videoEnd": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043748/Video/portal2_Be_kind_to_yourself_rahxff.mp4"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043748/Video/portal2_Be_kind_to_yourself_rahxff.mp4"
       }
     },
     "slides": [
@@ -48,7 +48,7 @@
         ],
         "content": {
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043753/Video/content_Be_kind_to_yourself_qfhuch.mp4",
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043753/Video/content_Be_kind_to_yourself_qfhuch.mp4",
             "autoPlayLoop": true
           }
         }
@@ -66,7 +66,7 @@
         "content": {
           "heading": "What do you say to yourself?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043760/Video/saring1_Be_kind_to_yourself_hokenn.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043760/Video/saring1_Be_kind_to_yourself_hokenn.mp4"
           }
         }
       },
@@ -75,7 +75,7 @@
         "content": {
           "heading": "What do you say to yourself?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043755/Video/sharing_timer_Be_kind_to_yourself_kwtwln.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043755/Video/sharing_timer_Be_kind_to_yourself_kwtwln.mp4"
           }
         },
         "hostNotes": [
@@ -97,7 +97,7 @@
           "video": {
             "durationTimer": false,
             "autoPlayLoop": false,
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043755/Video/sharing2_Be_kind_to_yourself_bu0qwe.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043755/Video/sharing2_Be_kind_to_yourself_bu0qwe.mp4"
           }
         },
         "hostNotes": [
@@ -114,7 +114,7 @@
         "content": {
           "heading": "What would you say to a friend?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043755/Video/sharing_timer_Be_kind_to_yourself_kwtwln.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043755/Video/sharing_timer_Be_kind_to_yourself_kwtwln.mp4"
           }
         },
         "hostNotes": [
@@ -162,11 +162,11 @@
         }
       ],
       "videoLoop": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043755/Video/portal1_Be_kind_to_yourself_u6lvok.mp4",
-        "audio": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043586/Audio/portal_audio_Be_kind_to_yourself_nnkrwz.mp3"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043755/Video/portal1_Be_kind_to_yourself_u6lvok.mp4",
+        "audio": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043586/Audio/portal_audio_Be_kind_to_yourself_nnkrwz.mp3"
       },
       "videoEnd": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043748/Video/portal2_Be_kind_to_yourself_rahxff.mp4"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043748/Video/portal2_Be_kind_to_yourself_rahxff.mp4"
       }
     },
     "slides": [
@@ -196,7 +196,7 @@
         ],
         "content": {
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043753/Video/content_Be_kind_to_yourself_qfhuch.mp4",
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043753/Video/content_Be_kind_to_yourself_qfhuch.mp4",
             "autoPlayLoop": true
           }
         }
@@ -214,7 +214,7 @@
         "content": {
           "heading": "What do you say to yourself?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043760/Video/saring1_Be_kind_to_yourself_hokenn.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043760/Video/saring1_Be_kind_to_yourself_hokenn.mp4"
           }
         }
       },
@@ -223,7 +223,7 @@
         "content": {
           "heading": "What do you say to yourself?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043755/Video/sharing_timer_Be_kind_to_yourself_kwtwln.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043755/Video/sharing_timer_Be_kind_to_yourself_kwtwln.mp4"
           }
         },
         "hostNotes": [
@@ -245,7 +245,7 @@
           "video": {
             "durationTimer": false,
             "autoPlayLoop": true,
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043755/Video/sharing2_Be_kind_to_yourself_bu0qwe.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043755/Video/sharing2_Be_kind_to_yourself_bu0qwe.mp4"
           }
         },
         "hostNotes": [
@@ -262,7 +262,7 @@
         "content": {
           "heading": "What would you say to a friend?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669043755/Video/sharing_timer_Be_kind_to_yourself_kwtwln.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669043755/Video/sharing_timer_Be_kind_to_yourself_kwtwln.mp4"
           }
         },
         "hostNotes": [

--- a/content/src/exercises/5b0dea9f-c665-41ce-a779-601d0cfa433d.json
+++ b/content/src/exercises/5b0dea9f-c665-41ce-a779-601d0cfa433d.json
@@ -14,11 +14,11 @@
         }
       ],
       "videoLoop": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667919733/Video/portal1_letting_go_of_control_g0izpw.mp4",
-        "audio": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667915462/Audio/portal_letting_go_of_controlmp3_eintur.mp3"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1667919733/Video/portal1_letting_go_of_control_g0izpw.mp4",
+        "audio": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1667915462/Audio/portal_letting_go_of_controlmp3_eintur.mp3"
       },
       "videoEnd": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1668093279/Video/portal2_letting_go_of_control_bnzxxr.mp4",
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1668093279/Video/portal2_letting_go_of_control_bnzxxr.mp4",
         "preview": ""
       }
     },
@@ -43,9 +43,9 @@
         ],
         "content": {
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1668679655/Video/meditation_letting_go_of_controlmp4_sxgwig.mp4",
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1668679655/Video/meditation_letting_go_of_controlmp4_sxgwig.mp4",
             "autoPlayLoop": false,
-            "audio": "https://res.cloudinary.com/cupcake-29k/video/upload/v1668093018/Audio/meditation_letting_go_of_control_becb1s.mp3",
+            "audio": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1668093018/Audio/meditation_letting_go_of_control_becb1s.mp3",
             "durationTimer": true
           }
         }
@@ -63,7 +63,7 @@
         "content": {
           "heading": "What's in your beachball?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669200641/Video/1min_letting_go_of_control_x23hr5.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669200641/Video/1min_letting_go_of_control_x23hr5.mp4"
           }
         }
       },
@@ -72,7 +72,7 @@
         "content": {
           "heading": "What's in your beachball?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669214353/Video/2min_letting_go_of_control_bzv8ur.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669214353/Video/2min_letting_go_of_control_bzv8ur.mp4"
           }
         },
         "hostNotes": [
@@ -106,7 +106,7 @@
         "content": {
           "heading": "What if you let go of your beachball?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669200641/Video/1min_letting_go_of_control_x23hr5.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669200641/Video/1min_letting_go_of_control_x23hr5.mp4"
           }
         }
       },
@@ -115,7 +115,7 @@
         "content": {
           "heading": "What if you let go of your beachball?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1669214353/Video/2min_letting_go_of_control_bzv8ur.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1669214353/Video/2min_letting_go_of_control_bzv8ur.mp4"
           }
         },
         "hostNotes": [
@@ -152,7 +152,7 @@
     },
     "outroPortal": {
       "video": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667919819/Video/mission_letting_go_of_control_audio_is2nnv.mp4"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1667919819/Video/mission_letting_go_of_control_audio_is2nnv.mp4"
       }
     }
   },

--- a/content/src/exercises/94575e97-fe03-4bfd-94a6-50aaf721d47e.json
+++ b/content/src/exercises/94575e97-fe03-4bfd-94a6-50aaf721d47e.json
@@ -31,8 +31,8 @@
         ],
         "content": {
           "video": {
-            "audio": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667298005/Audio/Agnes_bell_kmwzos_eznpow.mp3",
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667297532/Video/Accepting_thoughts_and_feelings_meditation_cn20lx.mp4",
+            "audio": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1667298005/Audio/Agnes_bell_kmwzos_eznpow.mp3",
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1667297532/Video/Accepting_thoughts_and_feelings_meditation_cn20lx.mp4",
             "autoPlayLoop": false,
             "durationTimer": true
           }
@@ -51,7 +51,7 @@
         "content": {
           "heading": "What did you notice?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667317097/Video/1min_Accepting_thoughts_and_feelings_xdvlcn.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1667317097/Video/1min_Accepting_thoughts_and_feelings_xdvlcn.mp4"
           }
         }
       },
@@ -60,7 +60,7 @@
         "content": {
           "heading": "What did you notice?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667317099/Video/2min_Accepting_thoughts_and_feelings_b9bxvx.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1667317099/Video/2min_Accepting_thoughts_and_feelings_b9bxvx.mp4"
           }
         },
         "hostNotes": [
@@ -97,11 +97,11 @@
         }
       ],
       "videoLoop": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667376603/Video/portal1_Accepting_thoughts_and_feelings_upvkxb.mp4",
-        "audio": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667317049/Audio/portal_Accepting_thoughts_and_feelings_ynb5i9.mp3"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1667376603/Video/portal1_Accepting_thoughts_and_feelings_upvkxb.mp4",
+        "audio": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1667317049/Audio/portal_Accepting_thoughts_and_feelings_ynb5i9.mp3"
       },
       "videoEnd": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667317594/Video/portal2_Accepting_thoughts_and_feelings_iyqnuk.mp4"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1667317594/Video/portal2_Accepting_thoughts_and_feelings_iyqnuk.mp4"
       }
     },
     "card": {
@@ -111,7 +111,7 @@
     },
     "outroPortal": {
       "video": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1667376603/Video/portal1_Accepting_thoughts_and_feelings_upvkxb.mp4"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1667376603/Video/portal1_Accepting_thoughts_and_feelings_upvkxb.mp4"
       }
     }
   },

--- a/content/src/exercises/ea0b48c1-745e-418d-93e7-2d8a6cd72898.json
+++ b/content/src/exercises/ea0b48c1-745e-418d-93e7-2d8a6cd72898.json
@@ -19,7 +19,7 @@
         "type": "content",
         "content": {
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1665464756/Temp/Comp_8_jsv5jo.mp4",
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1665464756/Temp/Comp_8_jsv5jo.mp4",
             "description": "",
             "preview": "",
             "autoPlayLoop": true
@@ -44,7 +44,7 @@
         "content": {
           "heading": "I would like to X, but I am so Y",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1665464767/Temp/Comp_4_wrr4ks.mp4",
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1665464767/Temp/Comp_4_wrr4ks.mp4",
             "autoPlayLoop": false
           }
         },
@@ -62,7 +62,7 @@
         "content": {
           "heading": "Switch to AND. What happens?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1665464773/Temp/Comp_9_bsizws.mp4",
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1665464773/Temp/Comp_9_bsizws.mp4",
             "autoPlayLoop": false
           }
         },
@@ -80,7 +80,7 @@
         "content": {
           "heading": "What happened when you switched to AND?",
           "video": {
-            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1665464766/Temp/Comp_10_ababts.mp4"
+            "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1665464766/Temp/Comp_10_ababts.mp4"
           }
         },
         "hostNotes": [
@@ -132,10 +132,10 @@
     },
     "introPortal": {
       "videoLoop": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1665480650/Temp/portal_no_sound_o7okas.mp4"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1665480650/Temp/portal_no_sound_o7okas.mp4"
       },
       "videoEnd": {
-        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/v1665469668/Temp/Comp_13_1_xmcpyo.mp4"
+        "source": "https://res.cloudinary.com/cupcake-29k/video/upload/q_auto:eco/v1665469668/Temp/Comp_13_1_xmcpyo.mp4"
       },
       "hostNotes": [
         {


### PR DESCRIPTION
Issue: https://29k.slack.com/archives/C7DTMLM6Y/p1669768023205229

Below you can see the `q_auto:eco` being `8.1mb`, the normal version as `15.4mb` and the `q_auto` version with `10.6mb`.

<img width="445" alt="Screenshot 2022-11-30 at 07 51 57" src="https://user-images.githubusercontent.com/7523828/204777394-8eb338f5-e681-48bd-a350-992182dad5f5.png">
