### PR TITLE
Minimise Session renderings

### DIFF
--- a/client/src/routes/Session/IntroPortal.tsx
+++ b/client/src/routes/Session/IntroPortal.tsx
@@ -45,6 +45,7 @@ import {ArrowLeftIcon} from '../../common/components/Icons';
 import useSubscribeToSessionIfFocused from './hooks/useSusbscribeToSessionIfFocused';
 import Badge from '../../common/components/Badge/Badge';
 import useSessionStartTime from './hooks/useSessionStartTime';
+import useExerciseById from '../../lib/content/hooks/useExerciseById';
 
 const VideoStyled = styled(VideoBase)({
   ...StyleSheet.absoluteFillObject,
@@ -92,8 +93,8 @@ const IntroPortal: React.FC = () => {
   const [loopVideoLoaded, setLoopVideoLoaded] = useState(false);
   const [joiningSession, setJoiningSession] = useState(false);
   const {t} = useTranslation('Screen.Portal');
-  const exercise = useSessionExercise();
   const session = useSessionState(state => state.session);
+  const exercise = useExerciseById(session?.contentId);
   const participants = useDailyState(state => state.participants);
   const participantsCount = Object.keys(participants ?? {}).length;
   const isHost = useIsSessionHost();

--- a/client/src/routes/Session/IntroPortal.tsx
+++ b/client/src/routes/Session/IntroPortal.tsx
@@ -30,7 +30,6 @@ import {
   TabNavigatorProps,
 } from '../../lib/navigation/constants/routes';
 import {SPACINGS} from '../../common/constants/spacings';
-import useSessionExercise from './hooks/useSessionExercise';
 import useSessionState from './state/state';
 import useDailyState from '../../lib/daily/state/state';
 import useLeaveSession from './hooks/useLeaveSession';

--- a/client/src/routes/Session/OutroPortal.tsx
+++ b/client/src/routes/Session/OutroPortal.tsx
@@ -8,7 +8,6 @@ import {
   TopSafeArea,
 } from '../../common/components/Spacers/Spacer';
 import {SPACINGS} from '../../common/constants/spacings';
-import useSessionExercise from './hooks/useSessionExercise';
 import useLeaveSession from './hooks/useLeaveSession';
 import VideoBase from './components/VideoBase/VideoBase';
 import usePreventGoingBack from '../../lib/navigation/hooks/usePreventGoingBack';
@@ -21,6 +20,8 @@ import {useTranslation} from 'react-i18next';
 import Gutters from '../../common/components/Gutters/Gutters';
 import AudioFader from './components/AudioFader/AudioFader';
 import Sentry from '../../lib/sentry';
+import useSessionState from './state/state';
+import useExerciseById from '../../lib/content/hooks/useExerciseById';
 
 const VideoStyled = styled(VideoBase)({
   ...StyleSheet.absoluteFillObject,
@@ -52,7 +53,8 @@ const TopBar = styled(Gutters)({
 const OutroPortal: React.FC = () => {
   const loopingVid = useRef<Video>(null);
   const [videoLoaded, setVideoLoaded] = useState(false);
-  const exercise = useSessionExercise();
+  const contentId = useSessionState(state => state.session?.contentId);
+  const exercise = useExerciseById(contentId);
   const {leaveSession} = useLeaveSession();
   const [readyToLeave, setReadyToLeave] = useState(false);
   const isFocused = useIsFocused();

--- a/client/src/routes/Session/Session.tsx
+++ b/client/src/routes/Session/Session.tsx
@@ -168,7 +168,7 @@ const Session = () => {
             )}
           </SpotlightContent>
         )}
-        <ExerciseControl sessionId={sessionId} />
+        <ExerciseControl sessionId={sessionId} exercise={exercise} />
       </Spotlight>
       <Participants participants={participants} />
       <Spacer16 />

--- a/client/src/routes/Session/Session.tsx
+++ b/client/src/routes/Session/Session.tsx
@@ -114,6 +114,7 @@ const Session = () => {
   const {leaveSessionWithConfirm} = useLeaveSession();
   const user = useUser();
   usePreventGoingBack(leaveSessionWithConfirm);
+  const backgroundColor = exercise?.theme?.backgroundColor;
 
   useEffect(() => {
     if (session?.ended) {
@@ -157,6 +158,7 @@ const Session = () => {
               current={exercise.slide.current}
               previous={exercise.slide.previous}
               next={exercise.slide.next}
+              backgroundColor={backgroundColor}
             />
             {!isHost && (
               <Progress

--- a/client/src/routes/Session/Session.tsx
+++ b/client/src/routes/Session/Session.tsx
@@ -114,7 +114,7 @@ const Session = () => {
   const {leaveSessionWithConfirm} = useLeaveSession();
   const user = useUser();
   usePreventGoingBack(leaveSessionWithConfirm);
-  const backgroundColor = exercise?.theme?.backgroundColor;
+  const theme = exercise?.theme;
 
   useEffect(() => {
     if (session?.ended) {
@@ -158,7 +158,7 @@ const Session = () => {
               current={exercise.slide.current}
               previous={exercise.slide.previous}
               next={exercise.slide.next}
-              backgroundColor={backgroundColor}
+              theme={theme}
             />
             {!isHost && (
               <Progress

--- a/client/src/routes/Session/components/ContentControls/ContentControls.tsx
+++ b/client/src/routes/Session/components/ContentControls/ContentControls.tsx
@@ -5,7 +5,7 @@ import {useTranslation} from 'react-i18next';
 
 import useIsSessionHost from '../../hooks/useIsSessionHost';
 import useSessionState from '../../state/state';
-import useSessionExercise from '../../hooks/useSessionExercise';
+import {SessionExercise} from '../../hooks/useSessionExercise';
 
 import {
   ChevronRight,
@@ -42,15 +42,16 @@ const IconSlideButton = styled(IconButton)(({disabled}) => ({
 type ContentControlsProps = {
   sessionId: string;
   style?: ViewStyle;
+  exercise: SessionExercise | null;
 };
 
 const ContentControls: React.FC<ContentControlsProps> = ({
   sessionId,
   style,
+  exercise,
 }) => {
   const isHost = useIsSessionHost();
   const exerciseState = useSessionState(state => state.session?.exerciseState);
-  const exercise = useSessionExercise();
   const {t} = useTranslation('Screen.Session');
 
   const {navigateToIndex, setPlaying} =

--- a/client/src/routes/Session/components/ExerciseSlides/ExerciseSlides.tsx
+++ b/client/src/routes/Session/components/ExerciseSlides/ExerciseSlides.tsx
@@ -49,21 +49,20 @@ const ExerciseSlides: React.FC<ExerciseSlidesProps> = ({
   current,
   previous,
   next,
-  theme,
 }) => (
   // "Pre load" previous and next slide
   <Wrapper>
     {previous && (
       <Fade visible={false} key={index - 1}>
-        <Slide theme={theme} slide={previous} active={false} />
+        <Slide slide={previous} active={false} />
       </Fade>
     )}
     <Fade visible={true} key={index}>
-      <Slide theme={theme} slide={current} active={true} />
+      <Slide slide={current} active={true} />
     </Fade>
     {next && (
       <Fade visible={false} key={index + 1}>
-        <Slide theme={theme} slide={next} active={false} />
+        <Slide slide={next} active={false} />
       </Fade>
     )}
   </Wrapper>

--- a/client/src/routes/Session/components/ExerciseSlides/ExerciseSlides.tsx
+++ b/client/src/routes/Session/components/ExerciseSlides/ExerciseSlides.tsx
@@ -7,6 +7,7 @@ import Animated, {
 } from 'react-native-reanimated';
 
 import {ExerciseSlide} from '../../../../../../shared/src/types/Content';
+import {ExerciseTheme} from '../../../../../../shared/src/types/generated/Exercise';
 import {StyleSheet} from 'react-native';
 import {Slide} from '../Slides/Slide';
 
@@ -40,7 +41,7 @@ type ExerciseSlidesProps = {
   current: ExerciseSlide;
   previous?: ExerciseSlide;
   next?: ExerciseSlide;
-  backgroundColor?: string;
+  theme?: ExerciseTheme;
 };
 
 const ExerciseSlides: React.FC<ExerciseSlidesProps> = ({
@@ -48,25 +49,21 @@ const ExerciseSlides: React.FC<ExerciseSlidesProps> = ({
   current,
   previous,
   next,
-  backgroundColor,
+  theme,
 }) => (
   // "Pre load" previous and next slide
   <Wrapper>
     {previous && (
       <Fade visible={false} key={index - 1}>
-        <Slide
-          backgroundColor={backgroundColor}
-          slide={previous}
-          active={false}
-        />
+        <Slide theme={theme} slide={previous} active={false} />
       </Fade>
     )}
     <Fade visible={true} key={index}>
-      <Slide backgroundColor={backgroundColor} slide={current} active={true} />
+      <Slide theme={theme} slide={current} active={true} />
     </Fade>
     {next && (
       <Fade visible={false} key={index + 1}>
-        <Slide backgroundColor={backgroundColor} slide={next} active={false} />
+        <Slide theme={theme} slide={next} active={false} />
       </Fade>
     )}
   </Wrapper>

--- a/client/src/routes/Session/components/ExerciseSlides/ExerciseSlides.tsx
+++ b/client/src/routes/Session/components/ExerciseSlides/ExerciseSlides.tsx
@@ -40,6 +40,7 @@ type ExerciseSlidesProps = {
   current: ExerciseSlide;
   previous?: ExerciseSlide;
   next?: ExerciseSlide;
+  backgroundColor?: string;
 };
 
 const ExerciseSlides: React.FC<ExerciseSlidesProps> = ({
@@ -47,20 +48,25 @@ const ExerciseSlides: React.FC<ExerciseSlidesProps> = ({
   current,
   previous,
   next,
+  backgroundColor,
 }) => (
   // "Pre load" previous and next slide
   <Wrapper>
     {previous && (
       <Fade visible={false} key={index - 1}>
-        <Slide slide={previous} active={false} />
+        <Slide
+          backgroundColor={backgroundColor}
+          slide={previous}
+          active={false}
+        />
       </Fade>
     )}
     <Fade visible={true} key={index}>
-      <Slide slide={current} active={true} />
+      <Slide backgroundColor={backgroundColor} slide={current} active={true} />
     </Fade>
     {next && (
       <Fade visible={false} key={index + 1}>
-        <Slide slide={next} active={false} />
+        <Slide backgroundColor={backgroundColor} slide={next} active={false} />
       </Fade>
     )}
   </Wrapper>

--- a/client/src/routes/Session/components/Slides/Slide.tsx
+++ b/client/src/routes/Session/components/Slides/Slide.tsx
@@ -4,6 +4,7 @@ import {ExerciseSlide} from '../../../../../../shared/src/types/Content';
 import Host from './Slides/Host';
 import {COLORS} from '../../../../../../shared/src/constants/colors';
 import Content from './Slides/Content';
+import {ExerciseTheme} from '../../../../../../shared/src/types/generated/Exercise';
 
 type WrapperProps = {backgroundColor?: string};
 const Wrapper = styled.View<WrapperProps>(({backgroundColor}) => ({
@@ -14,20 +15,24 @@ const Wrapper = styled.View<WrapperProps>(({backgroundColor}) => ({
 type SlideProps = {
   slide: ExerciseSlide;
   active: boolean;
-  backgroundColor?: string;
+  theme?: ExerciseTheme;
 };
 
-export const Slide = React.memo(
-  ({slide, active, backgroundColor}: SlideProps) => {
-    return (
-      <Wrapper backgroundColor={backgroundColor}>
-        {slide.type === 'host' && <Host active={active} />}
-        {slide.type === 'content' && <Content slide={slide} active={active} />}
-        {slide.type === 'reflection' && (
-          <Content slide={slide} active={active} />
-        )}
-        {slide.type === 'sharing' && <Content slide={slide} active={active} />}
-      </Wrapper>
-    );
-  },
-);
+export const Slide = React.memo(({slide, active, theme}: SlideProps) => {
+  return (
+    <Wrapper backgroundColor={theme?.backgroundColor}>
+      {slide.type === 'host' && (
+        <Host backgroundColor={theme?.backgroundColor} active={active} />
+      )}
+      {slide.type === 'content' && (
+        <Content textColor={theme?.textColor} slide={slide} active={active} />
+      )}
+      {slide.type === 'reflection' && (
+        <Content textColor={theme?.textColor} slide={slide} active={active} />
+      )}
+      {slide.type === 'sharing' && (
+        <Content textColor={theme?.textColor} slide={slide} active={active} />
+      )}
+    </Wrapper>
+  );
+});

--- a/client/src/routes/Session/components/Slides/Slide.tsx
+++ b/client/src/routes/Session/components/Slides/Slide.tsx
@@ -4,7 +4,6 @@ import {ExerciseSlide} from '../../../../../../shared/src/types/Content';
 import Host from './Slides/Host';
 import {COLORS} from '../../../../../../shared/src/constants/colors';
 import Content from './Slides/Content';
-import useSessionExercise from '../../hooks/useSessionExercise';
 
 type WrapperProps = {backgroundColor?: string};
 const Wrapper = styled.View<WrapperProps>(({backgroundColor}) => ({
@@ -15,16 +14,20 @@ const Wrapper = styled.View<WrapperProps>(({backgroundColor}) => ({
 type SlideProps = {
   slide: ExerciseSlide;
   active: boolean;
+  backgroundColor?: string;
 };
 
-export const Slide = React.memo(({slide, active}: SlideProps) => {
-  const exercise = useSessionExercise();
-  return (
-    <Wrapper backgroundColor={exercise?.theme?.backgroundColor}>
-      {slide.type === 'host' && <Host active={active} />}
-      {slide.type === 'content' && <Content slide={slide} active={active} />}
-      {slide.type === 'reflection' && <Content slide={slide} active={active} />}
-      {slide.type === 'sharing' && <Content slide={slide} active={active} />}
-    </Wrapper>
-  );
-});
+export const Slide = React.memo(
+  ({slide, active, backgroundColor}: SlideProps) => {
+    return (
+      <Wrapper backgroundColor={backgroundColor}>
+        {slide.type === 'host' && <Host active={active} />}
+        {slide.type === 'content' && <Content slide={slide} active={active} />}
+        {slide.type === 'reflection' && (
+          <Content slide={slide} active={active} />
+        )}
+        {slide.type === 'sharing' && <Content slide={slide} active={active} />}
+      </Wrapper>
+    );
+  },
+);

--- a/client/src/routes/Session/components/Slides/Slide.tsx
+++ b/client/src/routes/Session/components/Slides/Slide.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import styled from 'styled-components/native';
+
 import {ExerciseSlide} from '../../../../../../shared/src/types/Content';
 import Host from './Slides/Host';
 import {COLORS} from '../../../../../../shared/src/constants/colors';
 import Content from './Slides/Content';
-import {ExerciseTheme} from '../../../../../../shared/src/types/generated/Exercise';
+
+import useExerciseTheme from '../../hooks/useExerciseTheme';
 
 type WrapperProps = {backgroundColor?: string};
 const Wrapper = styled.View<WrapperProps>(({backgroundColor}) => ({
@@ -15,24 +17,17 @@ const Wrapper = styled.View<WrapperProps>(({backgroundColor}) => ({
 type SlideProps = {
   slide: ExerciseSlide;
   active: boolean;
-  theme?: ExerciseTheme;
 };
 
-export const Slide = React.memo(({slide, active, theme}: SlideProps) => {
+export const Slide = React.memo(({slide, active}: SlideProps) => {
+  const theme = useExerciseTheme();
+
   return (
     <Wrapper backgroundColor={theme?.backgroundColor}>
-      {slide.type === 'host' && (
-        <Host backgroundColor={theme?.backgroundColor} active={active} />
-      )}
-      {slide.type === 'content' && (
-        <Content textColor={theme?.textColor} slide={slide} active={active} />
-      )}
-      {slide.type === 'reflection' && (
-        <Content textColor={theme?.textColor} slide={slide} active={active} />
-      )}
-      {slide.type === 'sharing' && (
-        <Content textColor={theme?.textColor} slide={slide} active={active} />
-      )}
+      {slide.type === 'host' && <Host active={active} />}
+      {slide.type === 'content' && <Content slide={slide} active={active} />}
+      {slide.type === 'reflection' && <Content slide={slide} active={active} />}
+      {slide.type === 'sharing' && <Content slide={slide} active={active} />}
     </Wrapper>
   );
 });

--- a/client/src/routes/Session/components/Slides/Slides/Blocks/Heading.tsx
+++ b/client/src/routes/Session/components/Slides/Slides/Blocks/Heading.tsx
@@ -4,6 +4,7 @@ import {COLORS} from '../../../../../../../../shared/src/constants/colors';
 import Gutters from '../../../../../../common/components/Gutters/Gutters';
 import {Spacer12} from '../../../../../../common/components/Spacers/Spacer';
 import {Display24} from '../../../../../../common/components/Typography/Display/Display';
+import useExerciseTheme from '../../../../hooks/useExerciseTheme';
 
 type StyledHeadingProp = {textColor?: string};
 const StyledHeading = styled(Display24)<StyledHeadingProp>(({textColor}) => ({
@@ -11,14 +12,13 @@ const StyledHeading = styled(Display24)<StyledHeadingProp>(({textColor}) => ({
   color: textColor ?? COLORS.BLACK,
 }));
 
-const Heading: React.FC<{children: React.ReactNode; textColor?: string}> = ({
-  children,
-  textColor,
-}) => {
+const Heading: React.FC<{children: React.ReactNode}> = ({children}) => {
+  const theme = useExerciseTheme();
+
   return (
     <Gutters>
       <Spacer12 />
-      <StyledHeading textColor={textColor} numberOfLines={2}>
+      <StyledHeading textColor={theme?.textColor} numberOfLines={2}>
         {children}
       </StyledHeading>
     </Gutters>

--- a/client/src/routes/Session/components/Slides/Slides/Blocks/Heading.tsx
+++ b/client/src/routes/Session/components/Slides/Slides/Blocks/Heading.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components/native';
 import {COLORS} from '../../../../../../../../shared/src/constants/colors';
-import useSessionExercise from '../../../../hooks/useSessionExercise';
 import Gutters from '../../../../../../common/components/Gutters/Gutters';
 import {Spacer12} from '../../../../../../common/components/Spacers/Spacer';
 import {Display24} from '../../../../../../common/components/Typography/Display/Display';
@@ -12,13 +11,14 @@ const StyledHeading = styled(Display24)<StyledHeadingProp>(({textColor}) => ({
   color: textColor ?? COLORS.BLACK,
 }));
 
-const Heading: React.FC<{children: React.ReactNode}> = ({children}) => {
-  const exercise = useSessionExercise();
-
+const Heading: React.FC<{children: React.ReactNode; textColor?: string}> = ({
+  children,
+  textColor,
+}) => {
   return (
     <Gutters>
       <Spacer12 />
-      <StyledHeading textColor={exercise?.theme?.textColor} numberOfLines={2}>
+      <StyledHeading textColor={textColor} numberOfLines={2}>
         {children}
       </StyledHeading>
     </Gutters>

--- a/client/src/routes/Session/components/Slides/Slides/Blocks/Text.tsx
+++ b/client/src/routes/Session/components/Slides/Slides/Blocks/Text.tsx
@@ -4,6 +4,7 @@ import {COLORS} from '../../../../../../../../shared/src/constants/colors';
 import Gutters from '../../../../../../common/components/Gutters/Gutters';
 import {Spacer4} from '../../../../../../common/components/Spacers/Spacer';
 import {Display16} from '../../../../../../common/components/Typography/Display/Display';
+import useExerciseTheme from '../../../../hooks/useExerciseTheme';
 
 type StyledTextProp = {textColor?: string};
 const StyledText = styled(Display16)<StyledTextProp>(({textColor}) => ({
@@ -11,14 +12,13 @@ const StyledText = styled(Display16)<StyledTextProp>(({textColor}) => ({
   color: textColor ?? COLORS.BLACK,
 }));
 
-const Text: React.FC<{children: React.ReactNode; textColor?: string}> = ({
-  children,
-  textColor,
-}) => {
+const Text: React.FC<{children: React.ReactNode}> = ({children}) => {
+  const theme = useExerciseTheme();
+
   return (
     <Gutters>
       <Spacer4 />
-      <StyledText textColor={textColor} numberOfLines={2}>
+      <StyledText textColor={theme?.textColor} numberOfLines={2}>
         {children}
       </StyledText>
     </Gutters>

--- a/client/src/routes/Session/components/Slides/Slides/Blocks/Text.tsx
+++ b/client/src/routes/Session/components/Slides/Slides/Blocks/Text.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components/native';
 import {COLORS} from '../../../../../../../../shared/src/constants/colors';
-import useSessionExercise from '../../../../hooks/useSessionExercise';
 import Gutters from '../../../../../../common/components/Gutters/Gutters';
 import {Spacer4} from '../../../../../../common/components/Spacers/Spacer';
 import {Display16} from '../../../../../../common/components/Typography/Display/Display';
@@ -12,13 +11,14 @@ const StyledText = styled(Display16)<StyledTextProp>(({textColor}) => ({
   color: textColor ?? COLORS.BLACK,
 }));
 
-const Text: React.FC<{children: React.ReactNode}> = ({children}) => {
-  const exercise = useSessionExercise();
-
+const Text: React.FC<{children: React.ReactNode; textColor?: string}> = ({
+  children,
+  textColor,
+}) => {
   return (
     <Gutters>
       <Spacer4 />
-      <StyledText textColor={exercise?.theme?.textColor} numberOfLines={2}>
+      <StyledText textColor={textColor} numberOfLines={2}>
         {children}
       </StyledText>
     </Gutters>

--- a/client/src/routes/Session/components/Slides/Slides/Content.tsx
+++ b/client/src/routes/Session/components/Slides/Slides/Content.tsx
@@ -35,21 +35,28 @@ type ContentProps = {
     | ExerciseSlideSharingSlide
     | ExerciseSlideReflectionSlide;
   active: boolean;
+  textColor?: string;
 };
-const Content: React.FC<ContentProps> = ({slide: {content = {}}, active}) => (
+const Content: React.FC<ContentProps> = ({
+  slide: {content = {}},
+  active,
+  textColor,
+}) => (
   <>
     <Spacer12 />
     {!content.video && !content.image && (
       <TextWrapper>
-        {content.heading && <Heading>{content.heading}</Heading>}
-        {content.text && <Text>{content.text}</Text>}
+        {content.heading && (
+          <Heading textColor={textColor}>{content.heading}</Heading>
+        )}
+        {content.text && <Text textColor={textColor}>{content.text}</Text>}
       </TextWrapper>
     )}
     {(content.video || content.image) && content.heading && (
-      <Heading>{content.heading}</Heading>
+      <Heading textColor={textColor}>{content.heading}</Heading>
     )}
     {(content.video || content.image) && content.text && (
-      <Text>{content.text}</Text>
+      <Text textColor={textColor}>{content.text}</Text>
     )}
 
     {content.video ? (

--- a/client/src/routes/Session/components/Slides/Slides/Content.tsx
+++ b/client/src/routes/Session/components/Slides/Slides/Content.tsx
@@ -35,28 +35,21 @@ type ContentProps = {
     | ExerciseSlideSharingSlide
     | ExerciseSlideReflectionSlide;
   active: boolean;
-  textColor?: string;
 };
-const Content: React.FC<ContentProps> = ({
-  slide: {content = {}},
-  active,
-  textColor,
-}) => (
+const Content: React.FC<ContentProps> = ({slide: {content = {}}, active}) => (
   <>
     <Spacer12 />
     {!content.video && !content.image && (
       <TextWrapper>
-        {content.heading && (
-          <Heading textColor={textColor}>{content.heading}</Heading>
-        )}
-        {content.text && <Text textColor={textColor}>{content.text}</Text>}
+        {content.heading && <Heading>{content.heading}</Heading>}
+        {content.text && <Text>{content.text}</Text>}
       </TextWrapper>
     )}
     {(content.video || content.image) && content.heading && (
-      <Heading textColor={textColor}>{content.heading}</Heading>
+      <Heading>{content.heading}</Heading>
     )}
     {(content.video || content.image) && content.text && (
-      <Text textColor={textColor}>{content.text}</Text>
+      <Text>{content.text}</Text>
     )}
 
     {content.video ? (

--- a/client/src/routes/Session/components/Slides/Slides/Host.tsx
+++ b/client/src/routes/Session/components/Slides/Slides/Host.tsx
@@ -5,6 +5,7 @@ import hexToRgba from 'hex-to-rgba';
 import useSessionParticipantSpotlight from '../../../hooks/useSessionParticipantSpotlight';
 import Participant from '../../Participants/Participant';
 import {COLORS} from '../../../../../../../shared/src/constants/colors';
+import useExerciseTheme from '../../../hooks/useExerciseTheme';
 
 const Gradient = styled(LinearGradient)({
   position: 'absolute',
@@ -16,11 +17,13 @@ const Gradient = styled(LinearGradient)({
 
 type HostProps = {
   active: boolean;
-  backgroundColor?: string;
 };
-const Host: React.FC<HostProps> = ({active, backgroundColor}) => {
+const Host: React.FC<HostProps> = ({active}) => {
   const participantSpotlight = useSessionParticipantSpotlight();
-  const background = backgroundColor ?? COLORS.WHITE;
+
+  const theme = useExerciseTheme();
+  const background = theme?.backgroundColor ?? COLORS.WHITE;
+
   if (!active || !participantSpotlight) {
     return null;
   }

--- a/client/src/routes/Session/components/Slides/Slides/Host.tsx
+++ b/client/src/routes/Session/components/Slides/Slides/Host.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import LinearGradient from 'react-native-linear-gradient';
 import styled from 'styled-components/native';
 import hexToRgba from 'hex-to-rgba';
-import {COLORS} from '../../../../../../../shared/src/constants/colors';
-import useSessionExercise from '../../../hooks/useSessionExercise';
 import useSessionParticipantSpotlight from '../../../hooks/useSessionParticipantSpotlight';
 import Participant from '../../Participants/Participant';
+import {COLORS} from '../../../../../../../shared/src/constants/colors';
 
 const Gradient = styled(LinearGradient)({
   position: 'absolute',
@@ -17,23 +16,19 @@ const Gradient = styled(LinearGradient)({
 
 type HostProps = {
   active: boolean;
+  backgroundColor?: string;
 };
-const Host: React.FC<HostProps> = ({active}) => {
+const Host: React.FC<HostProps> = ({active, backgroundColor}) => {
   const participantSpotlight = useSessionParticipantSpotlight();
-  const exercise = useSessionExercise();
-
+  const background = backgroundColor ?? COLORS.WHITE;
   if (!active || !participantSpotlight) {
     return null;
   }
 
-  const backgroundColor = exercise?.theme?.backgroundColor ?? COLORS.WHITE;
-
   return (
     <>
       <Participant participant={participantSpotlight} />
-      <Gradient
-        colors={[hexToRgba(backgroundColor, 1), hexToRgba(backgroundColor, 0)]}
-      />
+      <Gradient colors={[hexToRgba(background, 1), hexToRgba(background, 0)]} />
     </>
   );
 };

--- a/client/src/routes/Session/hooks/useExerciseTheme.spec.ts
+++ b/client/src/routes/Session/hooks/useExerciseTheme.spec.ts
@@ -1,0 +1,31 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {useTranslation} from 'react-i18next';
+
+import {Session} from '../../../../../shared/src/types/Session';
+import useSessionState from '../state/state';
+import useExerciseTheme from './useExerciseTheme';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useExerciseTheme', () => {
+  const {t} = useTranslation();
+  (t as jest.Mock).mockReturnValue({theme: 'some-theme'});
+
+  it('returns current session exercise theme', async () => {
+    useSessionState.setState({
+      session: {contentId: 'some-content-id'} as Session,
+    });
+
+    const {result} = renderHook(() => useExerciseTheme());
+
+    expect(result.current).toBe('some-theme');
+  });
+
+  it('returns undefined', async () => {
+    const {result} = renderHook(() => useExerciseTheme());
+
+    expect(result.current).toBe(undefined);
+  });
+});

--- a/client/src/routes/Session/hooks/useExerciseTheme.tsx
+++ b/client/src/routes/Session/hooks/useExerciseTheme.tsx
@@ -1,0 +1,25 @@
+import {ExerciseSlide} from '../../../../../shared/src/types/Content';
+import {
+  Exercise,
+  ExerciseTheme,
+} from '../../../../../shared/src/types/generated/Exercise';
+import useExerciseById from '../../../lib/content/hooks/useExerciseById';
+import useSessionState from '../state/state';
+
+export type SessionExercise = Exercise & {
+  slide: {
+    index: number;
+    previous?: ExerciseSlide;
+    current: ExerciseSlide;
+    next?: ExerciseSlide;
+  };
+};
+
+const useExerciseTheme = (): ExerciseTheme | undefined => {
+  const contentId = useSessionState(state => state.session?.contentId);
+  const excerciseTheme = useExerciseById(contentId)?.theme;
+
+  return excerciseTheme;
+};
+
+export default useExerciseTheme;

--- a/client/src/routes/Session/hooks/useSessionExercise.ts
+++ b/client/src/routes/Session/hooks/useSessionExercise.ts
@@ -4,7 +4,7 @@ import {Exercise} from '../../../../../shared/src/types/generated/Exercise';
 import useExerciseById from '../../../lib/content/hooks/useExerciseById';
 import useSessionState from '../state/state';
 
-type SessionExercise = Exercise & {
+export type SessionExercise = Exercise & {
   slide: {
     index: number;
     previous?: ExerciseSlide;


### PR DESCRIPTION
Issue: <!-- Link to the issue related to your PR (if any). -->

### Description of the Change
Remove a bunch of re-rendingings caused by useSessionState.
**We can iterate and create a context to avoid the props passing of theme**

#### Screenshots

<!-- If client change - add screenshots for both platforms -->
| Before | After |
|-|-|
| 12 rerenders | Well, now we have 4 rerenders |
