### PR TITLE
Handle auth/argument-error errors correctly

### DIFF
--- a/functions/src/api/lib/firebaseAuth.spec.ts
+++ b/functions/src/api/lib/firebaseAuth.spec.ts
@@ -127,6 +127,34 @@ describe('firebaseAuth', () => {
     expect(next).toHaveBeenCalledTimes(0);
   });
 
+  it('returns 400 when token has incorrect arguments', async () => {
+    (getAuth().verifyIdToken as jest.Mock).mockRejectedValueOnce({
+      code: 'auth/argument-error',
+    });
+    const middleware = firebaseAuth();
+
+    const ctx = {
+      headers: {
+        authorization: 'bearer some-token',
+      },
+    } as FirebaseAuthContext;
+
+    const next = jest.fn();
+
+    await middleware(ctx, next);
+
+    expect(getAuth().verifyIdToken).toHaveBeenCalledTimes(1);
+
+    expect(ctx).toEqual({
+      status: 400,
+      headers: {
+        authorization: 'bearer some-token',
+      },
+    });
+
+    expect(next).toHaveBeenCalledTimes(0);
+  });
+
   it('throws on requests without authorization', async () => {
     const middleware = firebaseAuth();
 

--- a/functions/src/api/lib/firebaseAuth.ts
+++ b/functions/src/api/lib/firebaseAuth.ts
@@ -35,7 +35,8 @@ const firebaseAuth = () => async (ctx: FirebaseAuthContext, next: Next) => {
         return;
       }
       case 'auth/id-token-expired':
-      case 'auth/id-token-revoked': {
+      case 'auth/id-token-revoked':
+      case 'auth/argument-error': {
         ctx.status = 400;
         return;
       }


### PR DESCRIPTION
This happens when switching between different firebase environments

![image](https://user-images.githubusercontent.com/474066/205034920-58cc9fc5-7209-4f25-bf05-83b78a23ba40.png)
