### PR TITLE
Add re-edit session type

### DIFF
--- a/client/src/common/components/EditSessionType/EditSessionType.tsx
+++ b/client/src/common/components/EditSessionType/EditSessionType.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import {useTranslation} from 'react-i18next';
+import styled from 'styled-components/native';
+import {Session, SessionType} from '../../../../../shared/src/types/Session';
+import {ChevronLeft, PrivateIcon, PublicIcon} from '../Icons';
+import TouchableOpacity from '../TouchableOpacity/TouchableOpacity';
+import {Body16} from '../Typography/Body/Body';
+
+const Row = styled.View({
+  flexDirection: 'row',
+  alignItems: 'center',
+});
+
+const IconWrapper = styled.View({
+  width: 30,
+  height: 30,
+});
+
+const EditSessionType: React.FC<{
+  sessionType: Session['type'];
+  onPress: () => void;
+}> = ({sessionType, onPress}) => {
+  const {t} = useTranslation('Component.EditSessionType');
+
+  return (
+    <TouchableOpacity onPress={onPress}>
+      <Row>
+        <IconWrapper>
+          <ChevronLeft />
+        </IconWrapper>
+        <IconWrapper>
+          {sessionType === SessionType.private ? (
+            <PrivateIcon />
+          ) : (
+            <PublicIcon />
+          )}
+        </IconWrapper>
+        <Body16>{t(sessionType)}</Body16>
+      </Row>
+    </TouchableOpacity>
+  );
+};
+
+export default EditSessionType;

--- a/client/src/lib/content/hooks/useExerciseIds.ts
+++ b/client/src/lib/content/hooks/useExerciseIds.ts
@@ -1,6 +1,7 @@
 import {exerciseIds} from '../../../../../content/content.json';
 import {Exercise} from '../../../../../shared/src/types/generated/Exercise';
 
-const useExerciseIds = () => exerciseIds as Exercise['id'][];
+const useExerciseIds: () => Exercise['id'][] = () =>
+  exerciseIds as Exercise['id'][];
 
 export default useExerciseIds;

--- a/client/src/routes/CreateSessionModal/CreateSessionModal.tsx
+++ b/client/src/routes/CreateSessionModal/CreateSessionModal.tsx
@@ -1,302 +1,41 @@
-import {useIsFocused, useNavigation} from '@react-navigation/native';
-import dayjs from 'dayjs';
-import React, {Dispatch, SetStateAction, useState} from 'react';
-import {useTranslation} from 'react-i18next';
+import React, {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import Animated, {FadeIn, FadeOut} from 'react-native-reanimated';
 import styled from 'styled-components/native';
 
 import {Exercise} from '../../../../shared/src/types/generated/Exercise';
 import {SessionType} from '../../../../shared/src/types/Session';
-
-import useExerciseById from '../../lib/content/hooks/useExerciseById';
-import useExerciseIds from '../../lib/content/hooks/useExerciseIds';
-import useSessions from '../Sessions/hooks/useSessions';
-
-import Button from '../../common/components/Buttons/Button';
-import Gutters from '../../common/components/Gutters/Gutters';
-import Image from '../../common/components/Image/Image';
-import SheetModal from '../../common/components/Modals/SheetModal';
-import {
-  Spacer16,
-  Spacer24,
-  Spacer28,
-  Spacer8,
-} from '../../common/components/Spacers/Spacer';
-import TouchableOpacity from '../../common/components/TouchableOpacity/TouchableOpacity';
-import {
-  Display16,
-  Display24,
-} from '../../common/components/Typography/Display/Display';
-import {ModalHeading} from '../../common/components/Typography/Heading/Heading';
 import {COLORS} from '../../../../shared/src/constants/colors';
-import SETTINGS from '../../common/constants/settings';
-import {SPACINGS} from '../../common/constants/spacings';
-import {Body16} from '../../common/components/Typography/Body/Body';
-import DateTimePicker from './components/DateTimePicker';
-import {LANGUAGE_TAG} from '../../lib/i18n';
-import useIsPublicHost from '../../lib/user/hooks/useIsPublicHost';
-import {ModalStackProps} from '../../lib/navigation/constants/routes';
-import {NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {BottomSheetFlatList, useBottomSheet} from '@gorhom/bottom-sheet';
-import ProfileInfo from '../../common/components/ProfileInfo/ProfileInfo';
-import useUser from '../../lib/user/hooks/useUser';
-import Byline from '../../common/components/Bylines/Byline';
 import {UserProfile} from '../../../../shared/src/types/User';
-import {PrivateIcon, PublicIcon} from '../../common/components/Icons';
 
-const Row = styled.View({
-  flexDirection: 'row',
-});
+import useIsPublicHost from '../../lib/user/hooks/useIsPublicHost';
+import useUser from '../../lib/user/hooks/useUser';
 
-const Card = styled(TouchableOpacity)({
-  flexDirection: 'row',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  borderRadius: SETTINGS.BORDER_RADIUS.CARDS,
-  paddingRight: 0,
-  paddingLeft: SPACINGS.SIXTEEN,
-  backgroundColor: COLORS.CREAM,
-  overflow: 'hidden',
-});
+import SheetModal from '../../common/components/Modals/SheetModal';
 
-const TypeItemWrapper = styled.View({
-  flexDirection: 'row',
-  height: 96,
-  flex: 1,
-});
+import SelectTypeStep from './components/steps/SelectTypeStep';
+import SetDateTimeStep from './components/steps/SetDateTimeStep';
+import SelectContentStep from './components/steps/SelectContentStep';
+import UpdateProfileStep from './components/steps/ProfileStep';
 
-const IconWrapper = styled.View({
-  width: 30,
-  height: 30,
-});
-
-const CardImageWrapper = styled.View({
-  width: 80,
-  height: 80,
-});
-
-const TextWrapper = styled.View({
-  flex: 2,
-  paddingVertical: SPACINGS.SIXTEEN,
-});
-
-const Step = styled(Animated.View).attrs({
+export const Step = styled(Animated.View).attrs({
   entering: FadeIn.duration(300),
   exiting: FadeOut.duration(300),
 })({
   flex: 1,
 });
 
-const Cta = styled(Button)({alignSelf: 'center'});
-
-const TypeWrapper = styled(TouchableOpacity)({
-  justifyContent: 'center',
-  height: 96,
-  flex: 1,
-  backgroundColor: COLORS.PURE_WHITE,
-  borderRadius: SPACINGS.SIXTEEN,
-  paddingHorizontal: SPACINGS.SIXTEEN,
-});
-const TypeItemHeading = styled(ModalHeading)({
-  textAlign: 'left',
-  paddingHorizontal: SPACINGS.EIGHT,
-});
-
-const ContentCard: React.FC<{
-  exerciseId: Exercise['id'];
-  onPress: () => void;
-}> = ({exerciseId, onPress}) => {
-  const exercise = useExerciseById(exerciseId);
-
-  return (
-    <Gutters>
-      <Card onPress={onPress}>
-        <TextWrapper>
-          <Display16>{exercise?.name}</Display16>
-        </TextWrapper>
-        <Spacer16 />
-        <CardImageWrapper>
-          <Image source={{uri: exercise?.card?.image?.source}} />
-        </CardImageWrapper>
-      </Card>
-    </Gutters>
-  );
-};
-
-const UpdateProfile: React.FC<StepProps> = () => {
-  const {t} = useTranslation('Modal.CreateSession');
-  return (
-    <Gutters big>
-      <Spacer16 />
-      <ModalHeading>{t('profile.text')}</ModalHeading>
-      <Spacer16 />
-      <ProfileInfo />
-    </Gutters>
-  );
-};
-
-const SelectContent: React.FC<StepProps> = ({
-  nextStep,
-  setSelectedExercise,
-}) => {
-  const exerciseIds = useExerciseIds();
-
-  const {t} = useTranslation('Modal.CreateSession');
-
-  return (
-    <Step>
-      <BottomSheetFlatList
-        ListHeaderComponent={
-          <>
-            <ModalHeading>{t('selectContent.title')}</ModalHeading>
-            <Spacer16 />
-          </>
-        }
-        focusHook={useIsFocused}
-        data={exerciseIds}
-        ItemSeparatorComponent={Spacer16}
-        renderItem={({item}) => (
-          <ContentCard
-            onPress={() => {
-              setSelectedExercise(item);
-              nextStep();
-            }}
-            exerciseId={item}
-          />
-        )}
-      />
-      <Spacer24 />
-    </Step>
-  );
-};
-
-const TypeItem: React.FC<{
-  Icon: React.ReactNode;
-  label: string;
-  onPress: () => void;
-}> = ({Icon, label, onPress = () => {}}) => (
-  <TypeWrapper onPress={onPress}>
-    <IconWrapper>{Icon}</IconWrapper>
-    <Body16>{label}</Body16>
-  </TypeWrapper>
-);
-
-const SelectType: React.FC<StepProps> = ({
-  selectedExercise,
-  setSelectedType,
-  nextStep,
-  userProfile,
-}) => {
-  const exercise = useExerciseById(selectedExercise);
-  const {t} = useTranslation('Modal.CreateSession');
-
-  return (
-    <Step>
-      <Gutters>
-        <Spacer8 />
-        <Row>
-          <TextWrapper>
-            <Display24>{exercise?.name}</Display24>
-            <Spacer8 />
-            <Byline
-              pictureURL={userProfile.photoURL}
-              name={userProfile.displayName}
-            />
-          </TextWrapper>
-          <Spacer16 />
-          <CardImageWrapper>
-            <Image source={{uri: exercise?.card?.image?.source}} />
-          </CardImageWrapper>
-        </Row>
-        <Spacer28 />
-        <TypeItemHeading>{t('selectType.title')}</TypeItemHeading>
-        <Spacer16 />
-        <Row>
-          {Object.values(SessionType).map((type, i, arr) => (
-            <TypeItemWrapper key={i}>
-              <TypeItem
-                onPress={() => {
-                  setSelectedType(type);
-                  nextStep();
-                }}
-                label={t(`selectType.${type}.title`)}
-                Icon={type === 'private' ? <PrivateIcon /> : <PublicIcon />}
-              />
-              {i < arr.length - 1 && <Spacer16 />}
-            </TypeItemWrapper>
-          ))}
-        </Row>
-      </Gutters>
-    </Step>
-  );
-};
-
-const SetDateTime: React.FC<StepProps> = ({selectedExercise, selectedType}) => {
-  const {t, i18n} = useTranslation('Modal.CreateSession');
-  const {expand, collapse} = useBottomSheet();
-  const {goBack, navigate} =
-    useNavigation<NativeStackNavigationProp<ModalStackProps, 'SessionModal'>>();
-  const [isLoading, setIsLoading] = useState(false);
-  const [date, setDate] = useState<dayjs.Dayjs | undefined>();
-  const [time, setTime] = useState<dayjs.Dayjs | undefined>();
-  const {addSession} = useSessions();
-  const exercise = useExerciseById(selectedExercise);
-
-  const onSubmit = async () => {
-    if (selectedExercise && selectedType && date && time) {
-      const sessionDateTime = date.hour(time.hour()).minute(time.minute());
-
-      setIsLoading(true);
-      const session = await addSession({
-        contentId: selectedExercise,
-        type: selectedType,
-        startTime: sessionDateTime,
-        language: i18n.resolvedLanguage as LANGUAGE_TAG,
-      });
-      setIsLoading(false);
-      goBack();
-      navigate('SessionModal', {session});
-    }
-  };
-
-  return (
-    <Step>
-      <Gutters>
-        <Spacer8 />
-        <Row>
-          <TextWrapper>
-            <Display24>{exercise?.name}</Display24>
-          </TextWrapper>
-          <Spacer16 />
-          <CardImageWrapper>
-            <Image source={{uri: exercise?.card?.image?.source}} />
-          </CardImageWrapper>
-        </Row>
-        <Spacer28 />
-        <ModalHeading>{t('setDateTime.title')}</ModalHeading>
-        <Spacer16 />
-        <DateTimePicker
-          minimumDate={dayjs().local()}
-          onChange={(selectedDate, selectedTime) => {
-            setDate(selectedDate);
-            setTime(selectedTime);
-          }}
-          onToggle={expanded => (expanded ? expand() : collapse())}
-        />
-        <Spacer16 />
-        <Cta variant="secondary" small onPress={onSubmit} disabled={isLoading}>
-          {t('setDateTime.cta')}
-        </Cta>
-        <Spacer16 />
-      </Gutters>
-    </Step>
-  );
-};
-
-type StepProps = {
+export type StepProps = {
   selectedExercise: Exercise['id'] | undefined;
   setSelectedExercise: Dispatch<SetStateAction<StepProps['selectedExercise']>>;
   nextStep: () => void;
+  prevStep: () => void;
+  isPublicHost: boolean;
   selectedType: SessionType | undefined;
   userProfile: UserProfile;
   setSelectedType: Dispatch<SetStateAction<StepProps['selectedType']>>;
@@ -304,12 +43,12 @@ type StepProps = {
 
 const publicHostSteps = (hasProfile: boolean) =>
   hasProfile
-    ? [SelectContent, SelectType, SetDateTime]
-    : [UpdateProfile, SelectContent, SelectType, SetDateTime];
+    ? [SelectContentStep, SelectTypeStep, SetDateTimeStep]
+    : [UpdateProfileStep, SelectContentStep, SelectTypeStep, SetDateTimeStep];
 const normalUserSteps = (hasProfile: boolean) =>
   hasProfile
-    ? [SelectContent, SetDateTime]
-    : [UpdateProfile, SelectContent, SetDateTime];
+    ? [SelectContentStep, SetDateTimeStep]
+    : [UpdateProfileStep, SelectContentStep, SetDateTimeStep];
 
 const CreateSessionModal = () => {
   const [currentStep, setCurrentStep] = useState(0);
@@ -323,28 +62,47 @@ const CreateSessionModal = () => {
   );
 
   const hasProfile = Boolean(user?.displayName) && Boolean(user?.photoURL);
-  const userProfile = {
-    displayName: user?.displayName ?? undefined,
-    photoURL: user?.photoURL ?? undefined,
-  };
+  const userProfile = useMemo(
+    () => ({
+      displayName: user?.displayName ?? undefined,
+      photoURL: user?.photoURL ?? undefined,
+    }),
+    [user?.displayName, user?.photoURL],
+  );
 
-  const CurrentStepComponent: React.FC<StepProps> = isPublicHost
-    ? publicHostSteps(hasProfile)[currentStep]
-    : normalUserSteps(hasProfile)[currentStep];
+  const CurrentStepComponent: React.FC<StepProps> = useMemo(
+    () =>
+      isPublicHost
+        ? publicHostSteps(hasProfile)[currentStep]
+        : normalUserSteps(hasProfile)[currentStep],
+    [isPublicHost, currentStep, hasProfile],
+  );
 
-  const stepProps: StepProps = {
-    selectedExercise,
-    setSelectedExercise,
-    selectedType,
-    setSelectedType,
-    userProfile,
-    nextStep: () => setCurrentStep(currentStep + 1),
-  };
+  const prevStep = useCallback(
+    () => setCurrentStep(currentStep - 1),
+    [currentStep],
+  );
+
+  const nextStep = useCallback(
+    () => setCurrentStep(currentStep + 1),
+    [currentStep],
+  );
 
   return (
     <SheetModal
       backgroundColor={currentStep === 0 ? COLORS.WHITE : COLORS.CREAM}>
-      <CurrentStepComponent {...stepProps} />
+      <Step>
+        <CurrentStepComponent
+          selectedExercise={selectedExercise}
+          setSelectedExercise={setSelectedExercise}
+          selectedType={selectedType}
+          setSelectedType={setSelectedType}
+          userProfile={userProfile}
+          nextStep={nextStep}
+          prevStep={prevStep}
+          isPublicHost={isPublicHost}
+        />
+      </Step>
     </SheetModal>
   );
 };

--- a/client/src/routes/CreateSessionModal/components/DateTimePicker.tsx
+++ b/client/src/routes/CreateSessionModal/components/DateTimePicker.tsx
@@ -1,6 +1,14 @@
-import RNDateTimePicker from '@react-native-community/datetimepicker';
+import RNDateTimePicker, {
+  DateTimePickerEvent,
+} from '@react-native-community/datetimepicker';
 import dayjs from 'dayjs';
-import React, {Dispatch, SetStateAction, useEffect, useState} from 'react';
+import React, {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import {Platform} from 'react-native';
 import styled from 'styled-components/native';
 import utc from 'dayjs/plugin/utc';
@@ -41,6 +49,20 @@ const DateTimePicker: React.FC<{
   maximumDate?: dayjs.Dayjs;
   minimumDate?: dayjs.Dayjs;
 }> = ({mode, setValue, selectedValue, close, minimumDate, maximumDate}) => {
+  const onChangeIos = useCallback(
+    (_: DateTimePickerEvent, value: Date | undefined) =>
+      setValue(dayjs(value).utc()),
+    [setValue],
+  );
+
+  const onChangeAndroid = useCallback(
+    (_: DateTimePickerEvent, value: Date | undefined) => {
+      close();
+      setValue(dayjs(value).utc());
+    },
+    [close, setValue],
+  );
+
   switch (Platform.OS) {
     case 'ios':
       return (
@@ -50,7 +72,7 @@ const DateTimePicker: React.FC<{
           accentColor={COLORS.PRIMARY}
           display={mode === 'date' ? 'inline' : 'spinner'}
           value={selectedValue.local().toDate()}
-          onChange={(_, value) => setValue(dayjs(value).utc())}
+          onChange={onChangeIos}
           minimumDate={mode === 'date' ? minimumDate?.toDate() : undefined}
           maximumDate={mode === 'date' ? maximumDate?.toDate() : undefined}
         />
@@ -64,10 +86,7 @@ const DateTimePicker: React.FC<{
           value={selectedValue.local().toDate()}
           minimumDate={mode === 'date' ? minimumDate?.toDate() : undefined}
           maximumDate={mode === 'date' ? maximumDate?.toDate() : undefined}
-          onChange={(_, value) => {
-            close();
-            setValue(dayjs(value).utc());
-          }}
+          onChange={onChangeAndroid}
         />
       );
     default:
@@ -101,15 +120,27 @@ const Picker: React.FC<PickerProps> = ({
     [selectedDate, selectedTime, onChange],
   );
 
+  const onDatePress = useCallback(() => {
+    setShowTimePicker(false);
+    setShowDatePicker(!showDatePicker);
+    onToggle(!showDatePicker);
+  }, [setShowTimePicker, showDatePicker, onToggle]);
+
+  const onTimePress = useCallback(() => {
+    setShowTimePicker(false);
+    setShowDatePicker(!showDatePicker);
+    onToggle(!showDatePicker);
+  }, [setShowTimePicker, showDatePicker, onToggle]);
+
+  const onClose = useCallback(
+    () => setShowDatePicker(false),
+    [setShowDatePicker],
+  );
+
   return (
     <>
       <Wrapper>
-        <Row
-          onPress={() => {
-            setShowTimePicker(false);
-            setShowDatePicker(!showDatePicker);
-            onToggle(!showDatePicker);
-          }}>
+        <Row onPress={onDatePress}>
           <Body16>
             <BodyBold>{t('date')}</BodyBold>
           </Body16>
@@ -122,17 +153,12 @@ const Picker: React.FC<PickerProps> = ({
             mode="date"
             selectedValue={selectedDate}
             setValue={setSelectedDate}
-            close={() => setShowDatePicker(false)}
+            close={onClose}
             minimumDate={minimumDate}
             maximumDate={maximumDate}
           />
         )}
-        <Row
-          onPress={() => {
-            setShowDatePicker(false);
-            setShowTimePicker(!showTimePicker);
-            onToggle(!showTimePicker);
-          }}>
+        <Row onPress={onTimePress}>
           <Body16>
             <BodyBold>{t('time')}</BodyBold>
           </Body16>
@@ -145,7 +171,7 @@ const Picker: React.FC<PickerProps> = ({
             mode="time"
             selectedValue={selectedTime}
             setValue={setSelectedTime}
-            close={() => setShowTimePicker(false)}
+            close={onClose}
           />
         )}
       </Wrapper>

--- a/client/src/routes/CreateSessionModal/components/steps/ProfileStep.tsx
+++ b/client/src/routes/CreateSessionModal/components/steps/ProfileStep.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {useTranslation} from 'react-i18next';
+import Gutters from '../../../../common/components/Gutters/Gutters';
+import ProfileInfo from '../../../../common/components/ProfileInfo/ProfileInfo';
+import {Spacer16} from '../../../../common/components/Spacers/Spacer';
+import {ModalHeading} from '../../../../common/components/Typography/Heading/Heading';
+import {StepProps} from '../../CreateSessionModal';
+
+const UpdateProfileStep: React.FC<StepProps> = () => {
+  const {t} = useTranslation('Modal.CreateSession');
+  return (
+    <Gutters big>
+      <Spacer16 />
+      <ModalHeading>{t('profile.text')}</ModalHeading>
+      <Spacer16 />
+      <ProfileInfo />
+    </Gutters>
+  );
+};
+
+export default UpdateProfileStep;

--- a/client/src/routes/CreateSessionModal/components/steps/SelectContentStep.tsx
+++ b/client/src/routes/CreateSessionModal/components/steps/SelectContentStep.tsx
@@ -1,0 +1,109 @@
+import React, {useMemo} from 'react';
+import {BottomSheetFlatList} from '@gorhom/bottom-sheet';
+import {useIsFocused} from '@react-navigation/native';
+import {useCallback} from 'react';
+import {useTranslation} from 'react-i18next';
+import styled from 'styled-components/native';
+
+import SETTINGS from '../../../../common/constants/settings';
+import {COLORS} from '../../../../../../shared/src/constants/colors';
+import {SPACINGS} from '../../../../common/constants/spacings';
+
+import {Spacer16, Spacer24} from '../../../../common/components/Spacers/Spacer';
+import {ModalHeading} from '../../../../common/components/Typography/Heading/Heading';
+import useExerciseIds from '../../../../lib/content/hooks/useExerciseIds';
+import {StepProps} from '../../CreateSessionModal';
+import Gutters from '../../../../common/components/Gutters/Gutters';
+import useExerciseById from '../../../../lib/content/hooks/useExerciseById';
+import {Exercise} from '../../../../../../shared/src/types/generated/Exercise';
+import {Display16} from '../../../../common/components/Typography/Display/Display';
+import Image from '../../../../common/components/Image/Image';
+import TouchableOpacity from '../../../../common/components/TouchableOpacity/TouchableOpacity';
+
+const Card = styled(TouchableOpacity)({
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  borderRadius: SETTINGS.BORDER_RADIUS.CARDS,
+  paddingRight: 0,
+  paddingLeft: SPACINGS.SIXTEEN,
+  backgroundColor: COLORS.CREAM,
+  overflow: 'hidden',
+});
+
+const TextWrapper = styled.View({
+  flex: 2,
+  paddingVertical: SPACINGS.SIXTEEN,
+});
+
+const CardImageWrapper = styled.View({
+  width: 80,
+  height: 80,
+});
+
+const ContentCard: React.FC<{
+  exerciseId: Exercise['id'];
+  onPress: () => void;
+}> = ({exerciseId, onPress}) => {
+  const exercise = useExerciseById(exerciseId);
+  const exerciseImg = useMemo(
+    () => ({uri: exercise?.card?.image?.source}),
+    [exercise?.card?.image?.source],
+  );
+
+  return (
+    <Gutters>
+      <Card onPress={onPress}>
+        <TextWrapper>
+          <Display16>{exercise?.name}</Display16>
+        </TextWrapper>
+        <Spacer16 />
+        <CardImageWrapper>
+          <Image source={exerciseImg} />
+        </CardImageWrapper>
+      </Card>
+    </Gutters>
+  );
+};
+
+const SelectContentStep: React.FC<StepProps> = ({
+  nextStep,
+  setSelectedExercise,
+}) => {
+  const exerciseIds = useExerciseIds();
+
+  const {t} = useTranslation('Modal.CreateSession');
+
+  const renderItem = useCallback(
+    ({item}: {item: Exercise['id']}) => (
+      <ContentCard
+        onPress={() => {
+          setSelectedExercise(item);
+          nextStep();
+        }}
+        exerciseId={item}
+      />
+    ),
+    [setSelectedExercise, nextStep],
+  );
+
+  return (
+    <>
+      <BottomSheetFlatList
+        ListHeaderComponent={
+          <>
+            <ModalHeading>{t('selectContent.title')}</ModalHeading>
+            <Spacer16 />
+          </>
+        }
+        focusHook={useIsFocused}
+        data={exerciseIds}
+        ItemSeparatorComponent={Spacer16}
+        renderItem={renderItem}
+      />
+      <Spacer24 />
+    </>
+  );
+};
+
+export default SelectContentStep;

--- a/client/src/routes/CreateSessionModal/components/steps/SelectContentStep.tsx
+++ b/client/src/routes/CreateSessionModal/components/steps/SelectContentStep.tsx
@@ -48,7 +48,7 @@ const ContentCard: React.FC<{
   const exercise = useExerciseById(exerciseId);
   const exerciseImg = useMemo(
     () => ({uri: exercise?.card?.image?.source}),
-    [exercise?.card?.image?.source],
+    [exercise],
   );
 
   return (

--- a/client/src/routes/CreateSessionModal/components/steps/SelectTypeStep.tsx
+++ b/client/src/routes/CreateSessionModal/components/steps/SelectTypeStep.tsx
@@ -1,0 +1,131 @@
+import React, {useMemo} from 'react';
+import {useTranslation} from 'react-i18next';
+import styled from 'styled-components/native';
+import {COLORS} from '../../../../../../shared/src/constants/colors';
+import {SessionType} from '../../../../../../shared/src/types/Session';
+import Byline from '../../../../common/components/Bylines/Byline';
+import Gutters from '../../../../common/components/Gutters/Gutters';
+import {PrivateIcon, PublicIcon} from '../../../../common/components/Icons';
+import Image from '../../../../common/components/Image/Image';
+import {
+  Spacer16,
+  Spacer28,
+  Spacer8,
+} from '../../../../common/components/Spacers/Spacer';
+import TouchableOpacity from '../../../../common/components/TouchableOpacity/TouchableOpacity';
+import {Body16} from '../../../../common/components/Typography/Body/Body';
+import {Display24} from '../../../../common/components/Typography/Display/Display';
+import {ModalHeading} from '../../../../common/components/Typography/Heading/Heading';
+import {SPACINGS} from '../../../../common/constants/spacings';
+import useExerciseById from '../../../../lib/content/hooks/useExerciseById';
+import {StepProps} from '../../CreateSessionModal';
+
+const TypeItemWrapper = styled.View({
+  flexDirection: 'row',
+  height: 96,
+  flex: 1,
+});
+
+const TextWrapper = styled.View({
+  flex: 2,
+  paddingVertical: SPACINGS.SIXTEEN,
+});
+
+const IconWrapper = styled.View({
+  width: 30,
+  height: 30,
+});
+
+const TypeWrapper = styled(TouchableOpacity)({
+  justifyContent: 'center',
+  height: 96,
+  flex: 1,
+  backgroundColor: COLORS.PURE_WHITE,
+  borderRadius: SPACINGS.SIXTEEN,
+  paddingHorizontal: SPACINGS.SIXTEEN,
+});
+
+const TypeItemHeading = styled(ModalHeading)({
+  textAlign: 'left',
+  paddingHorizontal: SPACINGS.EIGHT,
+});
+
+const Row = styled.View({
+  flexDirection: 'row',
+  alignItems: 'center',
+});
+
+const CardImageWrapper = styled.View({
+  width: 80,
+  height: 80,
+});
+
+const TypeItem: React.FC<{
+  Icon: React.ReactNode;
+  label: string;
+  onPress: () => void;
+}> = ({Icon, label, onPress = () => {}}) => (
+  <TypeWrapper onPress={onPress}>
+    <IconWrapper>{Icon}</IconWrapper>
+    <Body16>{label}</Body16>
+  </TypeWrapper>
+);
+
+const SelectTypeStep: React.FC<StepProps> = ({
+  selectedExercise,
+  setSelectedType,
+  nextStep,
+  userProfile,
+}) => {
+  const exercise = useExerciseById(selectedExercise);
+  const {t} = useTranslation('Modal.CreateSession');
+
+  const sessionTypes = useMemo(
+    () =>
+      Object.values(SessionType).map((type, i, arr) => (
+        <TypeItemWrapper key={i}>
+          <TypeItem
+            onPress={() => {
+              setSelectedType(type);
+              nextStep();
+            }}
+            label={t(`selectType.${type}.title`)}
+            Icon={type === 'private' ? <PrivateIcon /> : <PublicIcon />}
+          />
+          {i < arr.length - 1 && <Spacer16 />}
+        </TypeItemWrapper>
+      )),
+    [t, nextStep, setSelectedType],
+  );
+
+  const exerciseImg = useMemo(
+    () => ({uri: exercise?.card?.image?.source}),
+    [exercise?.card?.image?.source],
+  );
+
+  return (
+    <Gutters>
+      <Spacer8 />
+      <Row>
+        <TextWrapper>
+          <Display24>{exercise?.name}</Display24>
+          <Spacer8 />
+          <Byline
+            pictureURL={userProfile.photoURL}
+            name={userProfile.displayName}
+          />
+        </TextWrapper>
+        <Spacer16 />
+        <CardImageWrapper>
+          <Image source={exerciseImg} />
+        </CardImageWrapper>
+      </Row>
+      <Spacer28 />
+      <TypeItemHeading>{t('selectType.title')}</TypeItemHeading>
+      <Spacer16 />
+      <Row>{sessionTypes}</Row>
+    </Gutters>
+  );
+};
+
+export default SelectTypeStep;

--- a/client/src/routes/CreateSessionModal/components/steps/SelectTypeStep.tsx
+++ b/client/src/routes/CreateSessionModal/components/steps/SelectTypeStep.tsx
@@ -100,7 +100,7 @@ const SelectTypeStep: React.FC<StepProps> = ({
 
   const exerciseImg = useMemo(
     () => ({uri: exercise?.card?.image?.source}),
-    [exercise?.card?.image?.source],
+    [exercise],
   );
 
   return (

--- a/client/src/routes/CreateSessionModal/components/steps/SetDateTimeStep.tsx
+++ b/client/src/routes/CreateSessionModal/components/steps/SetDateTimeStep.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import {useBottomSheet} from '@gorhom/bottom-sheet';
+import {useNavigation} from '@react-navigation/native';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import dayjs from 'dayjs';
+import {useCallback, useMemo, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {TouchableOpacity} from 'react-native-gesture-handler';
+import styled from 'styled-components/native';
+
+import Button from '../../../../common/components/Buttons/Button';
+import Byline from '../../../../common/components/Bylines/Byline';
+import Image from '../../../../common/components/Image/Image';
+import Gutters from '../../../../common/components/Gutters/Gutters';
+import {ChevronLeft, PrivateIcon} from '../../../../common/components/Icons';
+import {
+  Spacer16,
+  Spacer28,
+  Spacer8,
+} from '../../../../common/components/Spacers/Spacer';
+import {Body16} from '../../../../common/components/Typography/Body/Body';
+import {Display24} from '../../../../common/components/Typography/Display/Display';
+import useExerciseById from '../../../../lib/content/hooks/useExerciseById';
+import {LANGUAGE_TAG} from '../../../../lib/i18n';
+import {ModalStackProps} from '../../../../lib/navigation/constants/routes';
+import useSessions from '../../../Sessions/hooks/useSessions';
+import {StepProps} from '../../CreateSessionModal';
+import DateTimePicker from '../DateTimePicker';
+import {SPACINGS} from '../../../../common/constants/spacings';
+
+const TextWrapper = styled.View({
+  flex: 2,
+  paddingVertical: SPACINGS.SIXTEEN,
+});
+
+const Row = styled.View({
+  flexDirection: 'row',
+  alignItems: 'center',
+});
+
+const Cta = styled(Button)({alignSelf: 'center'});
+
+const IconWrapper = styled.View({
+  width: 30,
+  height: 30,
+});
+
+const CardImageWrapper = styled.View({
+  width: 80,
+  height: 80,
+});
+
+const SetDateTimeStep: React.FC<StepProps> = ({
+  selectedExercise,
+  selectedType,
+  isPublicHost,
+  userProfile,
+  prevStep,
+}) => {
+  const {t, i18n} = useTranslation('Modal.CreateSession');
+  const {expand, collapse} = useBottomSheet();
+  const {goBack, navigate} =
+    useNavigation<NativeStackNavigationProp<ModalStackProps, 'SessionModal'>>();
+  const [isLoading, setIsLoading] = useState(false);
+  const [date, setDate] = useState<dayjs.Dayjs | undefined>();
+  const [time, setTime] = useState<dayjs.Dayjs | undefined>();
+  const {addSession} = useSessions();
+  const exercise = useExerciseById(selectedExercise);
+
+  const onChange = useCallback(
+    (selectedDate: dayjs.Dayjs, selectedTime: dayjs.Dayjs) => {
+      setDate(selectedDate);
+      setTime(selectedTime);
+    },
+    [setDate, setTime],
+  );
+
+  const onSubmit = useCallback(async () => {
+    if (selectedExercise && selectedType && date && time) {
+      const sessionDateTime = date.hour(time.hour()).minute(time.minute());
+
+      setIsLoading(true);
+      const session = await addSession({
+        contentId: selectedExercise,
+        type: selectedType,
+        startTime: sessionDateTime,
+        language: i18n.resolvedLanguage as LANGUAGE_TAG,
+      });
+      setIsLoading(false);
+      goBack();
+      navigate('SessionModal', {session});
+    }
+  }, [
+    selectedExercise,
+    selectedType,
+    date,
+    time,
+    addSession,
+    goBack,
+    navigate,
+    i18n.resolvedLanguage,
+  ]);
+
+  const cardImg = useMemo(
+    () => ({uri: exercise?.card?.image?.source}),
+    [exercise?.card?.image?.source],
+  );
+
+  return (
+    <Gutters>
+      <Spacer8 />
+      <Row>
+        <TextWrapper>
+          <Display24>{exercise?.name}</Display24>
+          <Spacer8 />
+          <Byline
+            pictureURL={userProfile.photoURL}
+            name={userProfile.displayName}
+          />
+        </TextWrapper>
+        <Spacer16 />
+        <CardImageWrapper>
+          <Image source={cardImg} />
+        </CardImageWrapper>
+      </Row>
+      <Spacer28 />
+      {isPublicHost && selectedType && (
+        <TouchableOpacity onPress={prevStep}>
+          <Row>
+            <IconWrapper>
+              <ChevronLeft />
+            </IconWrapper>
+            <IconWrapper>
+              <PrivateIcon />
+            </IconWrapper>
+            <Body16>{t(`setDateTime.sessionType.${selectedType}`)}</Body16>
+          </Row>
+        </TouchableOpacity>
+      )}
+      <Spacer16 />
+      <DateTimePicker
+        minimumDate={dayjs().local()}
+        onChange={onChange}
+        onToggle={expanded => (expanded ? expand() : collapse())}
+      />
+      <Spacer16 />
+      <Cta variant="secondary" small onPress={onSubmit} disabled={isLoading}>
+        {t('setDateTime.cta')}
+      </Cta>
+      <Spacer16 />
+    </Gutters>
+  );
+};
+export default SetDateTimeStep;

--- a/client/src/routes/CreateSessionModal/components/steps/SetDateTimeStep.tsx
+++ b/client/src/routes/CreateSessionModal/components/steps/SetDateTimeStep.tsx
@@ -12,7 +12,11 @@ import Button from '../../../../common/components/Buttons/Button';
 import Byline from '../../../../common/components/Bylines/Byline';
 import Image from '../../../../common/components/Image/Image';
 import Gutters from '../../../../common/components/Gutters/Gutters';
-import {ChevronLeft, PrivateIcon} from '../../../../common/components/Icons';
+import {
+  ChevronLeft,
+  PrivateIcon,
+  PublicIcon,
+} from '../../../../common/components/Icons';
 import {
   Spacer16,
   Spacer28,
@@ -27,6 +31,7 @@ import useSessions from '../../../Sessions/hooks/useSessions';
 import {StepProps} from '../../CreateSessionModal';
 import DateTimePicker from '../DateTimePicker';
 import {SPACINGS} from '../../../../common/constants/spacings';
+import {SessionType} from '../../../../../../shared/src/types/Session';
 
 const TextWrapper = styled.View({
   flex: 2,
@@ -131,7 +136,11 @@ const SetDateTimeStep: React.FC<StepProps> = ({
               <ChevronLeft />
             </IconWrapper>
             <IconWrapper>
-              <PrivateIcon />
+              {selectedType === SessionType.private ? (
+                <PrivateIcon />
+              ) : (
+                <PublicIcon />
+              )}
             </IconWrapper>
             <Body16>{t(`setDateTime.sessionType.${selectedType}`)}</Body16>
           </Row>

--- a/client/src/routes/CreateSessionModal/components/steps/SetDateTimeStep.tsx
+++ b/client/src/routes/CreateSessionModal/components/steps/SetDateTimeStep.tsx
@@ -97,7 +97,7 @@ const SetDateTimeStep: React.FC<StepProps> = ({
 
   const cardImg = useMemo(
     () => ({uri: exercise?.card?.image?.source}),
-    [exercise?.card?.image?.source],
+    [exercise],
   );
 
   const onToggle = useCallback(

--- a/client/src/routes/CreateSessionModal/components/steps/SetDateTimeStep.tsx
+++ b/client/src/routes/CreateSessionModal/components/steps/SetDateTimeStep.tsx
@@ -5,7 +5,7 @@ import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import dayjs from 'dayjs';
 import {useCallback, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+
 import styled from 'styled-components/native';
 
 import Button from '../../../../common/components/Buttons/Button';
@@ -13,16 +13,10 @@ import Byline from '../../../../common/components/Bylines/Byline';
 import Image from '../../../../common/components/Image/Image';
 import Gutters from '../../../../common/components/Gutters/Gutters';
 import {
-  ChevronLeft,
-  PrivateIcon,
-  PublicIcon,
-} from '../../../../common/components/Icons';
-import {
   Spacer16,
   Spacer28,
   Spacer8,
 } from '../../../../common/components/Spacers/Spacer';
-import {Body16} from '../../../../common/components/Typography/Body/Body';
 import {Display24} from '../../../../common/components/Typography/Display/Display';
 import useExerciseById from '../../../../lib/content/hooks/useExerciseById';
 import {LANGUAGE_TAG} from '../../../../lib/i18n';
@@ -31,7 +25,7 @@ import useSessions from '../../../Sessions/hooks/useSessions';
 import {StepProps} from '../../CreateSessionModal';
 import DateTimePicker from '../DateTimePicker';
 import {SPACINGS} from '../../../../common/constants/spacings';
-import {SessionType} from '../../../../../../shared/src/types/Session';
+import EditSessionType from '../../../../common/components/EditSessionType/EditSessionType';
 
 const TextWrapper = styled.View({
   flex: 2,
@@ -44,11 +38,6 @@ const Row = styled.View({
 });
 
 const Cta = styled(Button)({alignSelf: 'center'});
-
-const IconWrapper = styled.View({
-  width: 30,
-  height: 30,
-});
 
 const CardImageWrapper = styled.View({
   width: 80,
@@ -111,6 +100,11 @@ const SetDateTimeStep: React.FC<StepProps> = ({
     [exercise?.card?.image?.source],
   );
 
+  const onToggle = useCallback(
+    (expanded: boolean) => (expanded ? expand() : collapse()),
+    [expand, collapse],
+  );
+
   return (
     <Gutters>
       <Spacer8 />
@@ -130,27 +124,13 @@ const SetDateTimeStep: React.FC<StepProps> = ({
       </Row>
       <Spacer28 />
       {isPublicHost && selectedType && (
-        <TouchableOpacity onPress={prevStep}>
-          <Row>
-            <IconWrapper>
-              <ChevronLeft />
-            </IconWrapper>
-            <IconWrapper>
-              {selectedType === SessionType.private ? (
-                <PrivateIcon />
-              ) : (
-                <PublicIcon />
-              )}
-            </IconWrapper>
-            <Body16>{t(`setDateTime.sessionType.${selectedType}`)}</Body16>
-          </Row>
-        </TouchableOpacity>
+        <EditSessionType sessionType={selectedType} onPress={prevStep} />
       )}
       <Spacer16 />
       <DateTimePicker
         minimumDate={dayjs().local()}
         onChange={onChange}
-        onToggle={expanded => (expanded ? expand() : collapse())}
+        onToggle={onToggle}
       />
       <Spacer16 />
       <Cta variant="secondary" small onPress={onSubmit} disabled={isLoading}>

--- a/client/src/routes/SessionModal/SessionModal.tsx
+++ b/client/src/routes/SessionModal/SessionModal.tsx
@@ -189,7 +189,7 @@ const SessionModal = () => {
       'Session Start Time': session.startTime,
     });
   }, [
-    exercise?.name,
+    exercise,
     session.startTime,
     session.type,
     session.contentId,

--- a/client/src/routes/SessionModal/SessionModal.tsx
+++ b/client/src/routes/SessionModal/SessionModal.tsx
@@ -1,6 +1,6 @@
 import {RouteProp, useNavigation, useRoute} from '@react-navigation/native';
 import dayjs from 'dayjs';
-import React, {useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {Alert, Share, View} from 'react-native';
@@ -9,7 +9,12 @@ import styled from 'styled-components/native';
 import Button from '../../common/components/Buttons/Button';
 import Gutters from '../../common/components/Gutters/Gutters';
 import IconButton from '../../common/components/Buttons/IconButton/IconButton';
-import {BellIcon, ShareIcon} from '../../common/components/Icons';
+import {
+  BellIcon,
+  PrivateIcon,
+  PublicIcon,
+  ShareIcon,
+} from '../../common/components/Icons';
 import Image from '../../common/components/Image/Image';
 import SheetModal from '../../common/components/Modals/SheetModal';
 import {
@@ -38,7 +43,24 @@ import {PencilIcon, CalendarIcon} from '../../common/components/Icons';
 import TouchableOpacity from '../../common/components/TouchableOpacity/TouchableOpacity';
 import DateTimePicker from '../CreateSessionModal/components/DateTimePicker';
 import {updateSession} from '../Sessions/api/session';
-import {Session} from '../../../../shared/src/types/Session';
+import {Session, SessionType} from '../../../../shared/src/types/Session';
+import EditSessionType from '../../common/components/EditSessionType/EditSessionType';
+import {SPACINGS} from '../../common/constants/spacings';
+import {ModalHeading} from '../../common/components/Typography/Heading/Heading';
+
+const TypeWrapper = styled(TouchableOpacity)({
+  justifyContent: 'center',
+  height: 96,
+  flex: 1,
+  backgroundColor: COLORS.PURE_WHITE,
+  borderRadius: SPACINGS.SIXTEEN,
+  paddingHorizontal: SPACINGS.SIXTEEN,
+});
+
+const TypeItemHeading = styled(ModalHeading)({
+  textAlign: 'left',
+  paddingHorizontal: SPACINGS.EIGHT,
+});
 
 const Content = styled(Gutters)({
   justifyContent: 'space-between',
@@ -78,17 +100,42 @@ const DeleteButton = styled(Button)({
   backgroundColor: COLORS.DELETE,
 });
 
+const TypeItemWrapper = styled.View({
+  flexDirection: 'row',
+  height: 96,
+  flex: 1,
+});
+
+const IconWrapper = styled.View({
+  width: 30,
+  height: 30,
+});
+
+const TypeItem: React.FC<{
+  Icon: React.ReactNode;
+  label: string;
+  onPress: () => void;
+}> = ({Icon, label, onPress = () => {}}) => (
+  <TypeWrapper onPress={onPress}>
+    <IconWrapper>{Icon}</IconWrapper>
+    <Body16>{label}</Body16>
+  </TypeWrapper>
+);
+
 const SessionModal = () => {
   const {
     params: {session: initialSessionData},
   } = useRoute<RouteProp<ModalStackProps, 'SessionModal'>>();
 
+  const [session, setSession] = useState<Session>(initialSessionData);
+
   const {t} = useTranslation('Modal.Session');
   const user = useUser();
   const {deleteSession, fetchSessions} = useSessions();
   const [editMode, setEditMode] = useState(false);
+  const [editTypeMode, setEditTypeMode] = useState(false);
+  const [selectedType, setSelectedType] = useState(session?.type);
 
-  const [session, setSession] = useState<Session>(initialSessionData);
   const initialStartTime = dayjs(session.startTime).utc();
   const [sessionDate, setSessionDate] = useState<dayjs.Dayjs>(initialStartTime);
   const [sessionTime, setSessionTime] = useState<dayjs.Dayjs>(initialStartTime);
@@ -104,11 +151,7 @@ const SessionModal = () => {
     .utc()
     .isAfter(initialStartTime.subtract(10, 'minutes'));
 
-  if (!session || !exercise) {
-    return null;
-  }
-
-  const onJoin = () => {
+  const onJoin = useCallback(() => {
     navigation.popToTop();
     navigation.navigate('SessionStack', {
       screen: 'ChangingRoom',
@@ -122,11 +165,18 @@ const SessionModal = () => {
       'Session Type': session.type,
       'Session Start Time': session.startTime,
     });
-  };
+  }, [
+    session.startTime,
+    session.type,
+    session.contentId,
+    session.language,
+    session.id,
+    navigation,
+  ]);
 
-  const onAddToCalendar = () => {
+  const onAddToCalendar = useCallback(() => {
     addToCalendar(
-      exercise.name,
+      exercise?.name,
       session.hostProfile?.displayName,
       session.link,
       dayjs(session.startTime),
@@ -138,9 +188,18 @@ const SessionModal = () => {
       'Session Type': session.type,
       'Session Start Time': session.startTime,
     });
-  };
+  }, [
+    exercise?.name,
+    session.startTime,
+    session.type,
+    session.contentId,
+    session.language,
+    addToCalendar,
+    session.hostProfile?.displayName,
+    session.link,
+  ]);
 
-  const onToggleReminder = () => {
+  const onToggleReminder = useCallback(() => {
     toggleReminder(!reminderEnabled);
     if (!reminderEnabled) {
       metrics.logEvent('Add Session Reminder', {
@@ -150,9 +209,16 @@ const SessionModal = () => {
         'Session Start Time': session.startTime,
       });
     }
-  };
+  }, [
+    reminderEnabled,
+    session.contentId,
+    session.language,
+    session.type,
+    session.startTime,
+    toggleReminder,
+  ]);
 
-  const onShare = () => {
+  const onShare = useCallback(() => {
     if (session.link) {
       Share.share({
         message: t('shareMessage', {
@@ -162,9 +228,9 @@ const SessionModal = () => {
         }),
       });
     }
-  };
+  }, [session.link, session.inviteCode, t]);
 
-  const onDelete = () => {
+  const onDelete = useCallback(() => {
     Alert.alert(t('delete.header'), t('delete.text'), [
       {text: t('delete.buttons.cancel'), style: 'cancel', onPress: () => {}},
       {
@@ -177,7 +243,73 @@ const SessionModal = () => {
         },
       },
     ]);
-  };
+  }, [t, navigation, deleteSession, session.id]);
+
+  const onUpdateSession = useCallback(async () => {
+    const sessionDateTime = sessionDate
+      .hour(sessionTime.hour())
+      .minute(sessionTime.minute());
+
+    const updatedSession = await updateSession(session.id, {
+      startTime: sessionDateTime.utc().toISOString(),
+      type: selectedType,
+    });
+
+    setSession(updatedSession);
+    fetchSessions();
+    setEditMode(false);
+  }, [
+    setSession,
+    fetchSessions,
+    setEditMode,
+    sessionTime,
+    sessionDate,
+    session.id,
+    selectedType,
+  ]);
+
+  const onChange = useCallback(
+    (date: dayjs.Dayjs, time: dayjs.Dayjs) => {
+      setSessionDate(date);
+      setSessionTime(time);
+    },
+    [setSessionDate, setSessionTime],
+  );
+
+  const onEditMode = useCallback(() => setEditMode(true), [setEditMode]);
+
+  const onEditType = useCallback(
+    () => setEditTypeMode(true),
+    [setEditTypeMode],
+  );
+
+  useEffect(() => {
+    if (!editMode) {
+      setEditTypeMode(false);
+    }
+  }, [editMode]);
+
+  const sessionTypes = useMemo(
+    () =>
+      Object.values(SessionType).map((type, i, arr) => (
+        <TypeItemWrapper key={i}>
+          <TypeItem
+            onPress={() => {
+              setSelectedType(type);
+              setEditTypeMode(false);
+            }}
+            label={t(`selectType.${type}.title`)}
+            Icon={type === 'private' ? <PrivateIcon /> : <PublicIcon />}
+          />
+          {i < arr.length - 1 && <Spacer16 />}
+        </TypeItemWrapper>
+      )),
+    [t],
+  );
+
+  if (!session || !exercise) {
+    return null;
+  }
 
   return (
     <SheetModal>
@@ -213,7 +345,7 @@ const SessionModal = () => {
                 </>
               )}
               {user?.uid === session.hostId && (
-                <EditButton onPress={() => setEditMode(true)}>
+                <EditButton onPress={onEditMode}>
                   <SessionTimeBadge session={session} />
                   <EditIcon>
                     <PencilIcon />
@@ -266,37 +398,36 @@ const SessionModal = () => {
       )}
       {editMode && (
         <Gutters>
-          <DateTimePicker
-            initialDateTime={initialStartTime}
-            minimumDate={dayjs().local()}
-            onChange={(date, time) => {
-              setSessionDate(date);
-              setSessionTime(time);
-            }}
-          />
-          <Spacer16 />
-          <SpaceBetweenRow>
-            <Button
-              variant="secondary"
-              onPress={async () => {
-                const sessionDateTime = sessionDate
-                  .hour(sessionTime.hour())
-                  .minute(sessionTime.minute());
-
-                const updatedSession = await updateSession(session.id, {
-                  startTime: sessionDateTime.utc().toISOString(),
-                });
-
-                setSession(updatedSession);
-                fetchSessions();
-                setEditMode(false);
-              }}>
-              {t('done')}
-            </Button>
-            <DeleteButton small onPress={onDelete}>
-              {t('deleteButton')}
-            </DeleteButton>
-          </SpaceBetweenRow>
+          {editTypeMode && (
+            <>
+              <TypeItemHeading>{t('selectType.title')}</TypeItemHeading>
+              <Spacer16 />
+              <Row>{sessionTypes}</Row>
+            </>
+          )}
+          {!editTypeMode && (
+            <>
+              <EditSessionType
+                sessionType={selectedType}
+                onPress={onEditType}
+              />
+              <Spacer16 />
+              <DateTimePicker
+                initialDateTime={initialStartTime}
+                minimumDate={dayjs().local()}
+                onChange={onChange}
+              />
+              <Spacer16 />
+              <SpaceBetweenRow>
+                <Button variant="secondary" onPress={onUpdateSession}>
+                  {t('done')}
+                </Button>
+                <DeleteButton small onPress={onDelete}>
+                  {t('deleteButton')}
+                </DeleteButton>
+              </SpaceBetweenRow>
+            </>
+          )}
         </Gutters>
       )}
     </SheetModal>

--- a/client/src/routes/Sessions/api/session.ts
+++ b/client/src/routes/Sessions/api/session.ts
@@ -32,7 +32,7 @@ export const addSession = async ({
 
 export const updateSession = async (
   id: string,
-  data: Partial<Pick<Session, 'started' | 'ended' | 'startTime'>>,
+  data: Partial<Pick<Session, 'started' | 'ended' | 'startTime' | 'type'>>,
 ): Promise<Session> => {
   try {
     const response = await apiClient(`${SESSIONS_ENDPOINT}/${id}`, {

--- a/content/src/ui/Component.EditSessionType.json
+++ b/content/src/ui/Component.EditSessionType.json
@@ -1,0 +1,9 @@
+{
+  "en": {
+    "private": "Session with Friends",
+    "public": "Session with Anyone"
+  },
+  "sv": {},
+  "pt": {},
+  "es": {}
+}

--- a/content/src/ui/Modal.CreateSession.json
+++ b/content/src/ui/Modal.CreateSession.json
@@ -20,7 +20,11 @@
     },
     "setDateTime": {
       "title": "Choose a time",
-      "cta": "Create session"
+      "cta": "Create session",
+      "sessionType": {
+        "private": "Session with Friends",
+        "public": "Session with Anyone"
+      }
     },
     "profile": {
       "text": "To create and host a session you need a user name and profile picture."

--- a/content/src/ui/Modal.CreateSession.json
+++ b/content/src/ui/Modal.CreateSession.json
@@ -6,16 +6,13 @@
     "selectType": {
       "title": "Create session with...",
       "public": {
-        "title": "Anyone",
-        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+        "title": "Anyone"
       },
       "private": {
-        "title": "Friends",
-        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+        "title": "Friends"
       },
       "async": {
-        "title": "Myself",
-        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+        "title": "Myself"
       }
     },
     "setDateTime": {
@@ -37,16 +34,13 @@
     "selectType": {
       "title": "Criar sessão com...",
       "public": {
-        "title": "Qualquer pessoa",
-        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+        "title": "Qualquer pessoa"
       },
       "private": {
-        "title": "Os meus amigos",
-        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+        "title": "Os meus amigos"
       },
       "async": {
-        "title": "Comigo",
-        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+        "title": "Comigo"
       }
     },
     "setDateTime": {
@@ -64,16 +58,13 @@
     "selectType": {
       "title": "Skapa session för...",
       "public": {
-        "title": "Alla",
-        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+        "title": "Alla"
       },
       "private": {
-        "title": "Mina vänner",
-        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+        "title": "Mina vänner"
       },
       "async": {
-        "title": "Mig själv",
-        "icon": "https://res.cloudinary.com/twentyninek/image/upload/v1664528333/temp/pure-simple-love_rd2wvb.png"
+        "title": "Mig själv"
       }
     },
     "setDateTime": {

--- a/content/src/ui/Modal.Session.json
+++ b/content/src/ui/Modal.Session.json
@@ -11,6 +11,18 @@
         "confirm": "Delete"
       }
     },
+    "selectType": {
+      "title": "Session with...",
+      "public": {
+        "title": "Anyone"
+      },
+      "private": {
+        "title": "Friends"
+      },
+      "async": {
+        "title": "Myself"
+      }
+    },
     "join": "Join",
     "shareMessage": "{{link}}\nSession code: {{code}}",
     "description": "Add to calendar, set reminder or share the code to invite friends"
@@ -27,9 +39,21 @@
         "confirm": "Remover"
       }
     },
-    "join": "Aderir",
+    "join": "Juntar",
     "shareMessage": "{{link}}Código da sessão: {{code}}",
-    "description": "Adiciona ao calendário, configura um lembrete ou partilha o código para convidares os teus amigos."
+    "description": "Adiciona ao calendário, configura um lembrete ou partilha o código para convidares os teus amigos.",
+    "selectType": {
+      "title": "Sessão com...",
+      "public": {
+        "title": "Qualquer pessoa"
+      },
+      "private": {
+        "title": "Os meus amigos"
+      },
+      "async": {
+        "title": "Comigo"
+      }
+    }
   },
   "sv": {
     "edit": "Ändra",
@@ -41,6 +65,18 @@
       "buttons": {
         "cancel": "Avbryt",
         "confirm": "Ta bort"
+      }
+    },
+    "selectType": {
+      "title": "Session för...",
+      "public": {
+        "title": "Alla"
+      },
+      "private": {
+        "title": "Mina vänner"
+      },
+      "async": {
+        "title": "Mig själv"
       }
     },
     "join": "Gå med"

--- a/functions/src/api/sessions/index.ts
+++ b/functions/src/api/sessions/index.ts
@@ -111,7 +111,7 @@ const UpdateSessionSchema = yup
     started: yup.boolean(),
     ended: yup.boolean(),
     startTime: yup.string(),
-    type: yup.mixed<SessionType>().oneOf(Object.values(SessionType)).required(),
+    type: yup.mixed<SessionType>().oneOf(Object.values(SessionType)),
   })
   .test(
     'nonEmptyObject',

--- a/functions/src/api/sessions/index.ts
+++ b/functions/src/api/sessions/index.ts
@@ -111,6 +111,7 @@ const UpdateSessionSchema = yup
     started: yup.boolean(),
     ended: yup.boolean(),
     startTime: yup.string(),
+    type: yup.mixed<SessionType>().oneOf(Object.values(SessionType)).required(),
   })
   .test(
     'nonEmptyObject',


### PR DESCRIPTION
Issue: [Notion Task ⛑️ ](https://www.notion.so/29k/Early-Access-2794500652b34c64b0aff0dbbc53e0ab#52a1b76699e546d693178736b84b614b)

- [x] Add it to create session flow
- [x] Edit existing session flow

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Add session type copy and re-edit functionality.

### Screenshots

#### Creating a session

Session type icon on the video below is not updating according to the type, [e57f3c5](https://github.com/29ki/29k/pull/1169/commits/e57f3c51b634cf1113aa0c281cefdab6dfafe7e9) fixes that 😬 

https://user-images.githubusercontent.com/7523828/205902112-80a71002-4d98-4fac-bfce-34dbdfafcbfd.mp4

#### Editing an existing session

https://user-images.githubusercontent.com/7523828/205930791-0455d921-2c1f-4412-9d6a-f3903e0d5384.mp4



