### PR TITLE
Update daily room expiry date when updating session startTime

### DIFF
--- a/functions/src/controllers/sessions.spec.ts
+++ b/functions/src/controllers/sessions.spec.ts
@@ -9,6 +9,11 @@ const mockDailyApi = {
     url: 'http://fake.daily/url',
     name: 'some-fake-daily-room-name',
   })),
+  updateRoom: jest.fn(() => ({
+    id: 'some-fake-daily-id',
+    url: 'http://fake.daily/url',
+    name: 'some-fake-daily-room-name',
+  })),
   deleteRoom: jest.fn(),
 };
 
@@ -305,6 +310,46 @@ describe('sessions - controller', () => {
       await expect(
         updateSession('not-the-host-id', 'some-session-id', {started: true}),
       ).rejects.toEqual(Error('user-unauthorized'));
+    });
+
+    it('should update the room expiry date to new startTime + 2h', async () => {
+      mockGetSessionById.mockResolvedValueOnce({
+        id: 'some-session-id',
+        dailyRoomName: 'some-daily-room-name',
+        hostId: 'the-host-id',
+        startTime: new Date('2022-10-10T10:00:00Z').toISOString(),
+      });
+      mockGetSessionById.mockResolvedValueOnce({
+        id: 'some-session-id',
+      }); // second call (returned value)
+
+      await updateSession('the-host-id', 'some-session-id', {
+        startTime: new Date('2022-10-10T18:00:00Z').toISOString(),
+      });
+
+      expect(mockUpdateSession).toHaveBeenCalledWith('some-session-id', {
+        startTime: new Date('2022-10-10T18:00:00Z').toISOString(),
+      });
+      expect(mockDailyApi.updateRoom).toHaveBeenCalledWith(
+        'some-daily-room-name',
+        // startTime + 2h
+        dayjs('2022-10-10T20:00:00.000Z'),
+      );
+    });
+
+    it('should not update room if startTime did not change', async () => {
+      mockGetSessionById.mockResolvedValueOnce({
+        id: 'some-session-id',
+        dailyRoomName: 'some-daily-room-name',
+        hostId: 'the-host-id',
+        startTime: new Date('2022-10-10T10:00:00Z').toISOString(),
+      });
+
+      await updateSession('the-host-id', 'some-session-id', {
+        startTime: new Date('2022-10-10T10:00:00Z').toISOString(),
+      });
+
+      expect(mockDailyApi.updateRoom).toHaveBeenCalledTimes(0);
     });
 
     it('should update the session and return it', async () => {

--- a/functions/src/controllers/sessions.ts
+++ b/functions/src/controllers/sessions.ts
@@ -84,10 +84,19 @@ export const updateSession = async (
   sessionId: Session['id'],
   data: Partial<UpdateSession>,
 ) => {
-  const session = (await sessionModel.getSessionById(sessionId)) as Session;
+  const session = (await sessionModel.getSessionById(sessionId)) as Session & {
+    dailyRoomName: string;
+  };
 
   if (userId !== session?.hostId) {
     throw new Error('user-unauthorized');
+  }
+
+  if (data.startTime && session.startTime !== data.startTime) {
+    dailyApi.updateRoom(
+      session.dailyRoomName,
+      dayjs(data.startTime).add(2, 'hour'),
+    );
   }
 
   await sessionModel.updateSession(sessionId, removeEmpty(data));

--- a/functions/src/lib/dailyApi.spec.ts
+++ b/functions/src/lib/dailyApi.spec.ts
@@ -3,7 +3,7 @@ import fetchMock, {enableFetchMocks} from 'jest-fetch-mock';
 
 enableFetchMocks();
 
-import {createRoom, deleteRoom} from './dailyApi';
+import {createRoom, deleteRoom, updateRoom} from './dailyApi';
 
 afterEach(() => {
   fetchMock.resetMocks();
@@ -45,6 +45,47 @@ describe('dailyApi', () => {
 
       await expect(createRoom(expireDate)).rejects.toThrow(
         new Error('Failed creating room, some-body'),
+      );
+    });
+  });
+
+  describe('updateRoom', () => {
+    it('returns an updated room from the Daily API', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({id: 'some-id', name: 'some-name'}),
+      );
+
+      const expireDate = dayjs('2020-01-01T01:01:01.000Z');
+
+      const room = await updateRoom('some-name', expireDate);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.daily.co/v1/rooms/some-name',
+        {
+          headers: {
+            Authorization: 'Bearer some-api-endpoint',
+            'Content-Type': 'application/json',
+          },
+          method: 'POST',
+          body: JSON.stringify({
+            properties: {
+              exp: 1577840461,
+              start_audio_off: true,
+              start_video_off: false,
+            },
+          }),
+        },
+      );
+      expect(room).toEqual({id: 'some-id', name: 'some-name'});
+    });
+
+    it('throws when not ok', async () => {
+      fetchMock.mockResponseOnce('some-body', {status: 500});
+
+      const expireDate = dayjs('2020-01-01T01:01:01.000Z');
+
+      await expect(updateRoom('some-name', expireDate)).rejects.toThrow(
+        new Error('Failed updating room, some-body'),
       );
     });
   });

--- a/functions/src/lib/dailyApi.ts
+++ b/functions/src/lib/dailyApi.ts
@@ -52,6 +52,32 @@ export const createRoom = async (expireDate: Dayjs): Promise<Room> => {
   return res.json();
 };
 
+export const updateRoom = async (
+  name: Room['name'],
+  expireDate: Dayjs,
+): Promise<Room> => {
+  const res = await fetch(`${DAILY_API_URL}/rooms/${name}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${DAILY_API_KEY}`,
+    },
+    body: JSON.stringify({
+      properties: {
+        exp: expireDate.unix(),
+        start_audio_off: true,
+        start_video_off: false,
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed updating room, ${res.body}`);
+  }
+
+  return res.json();
+};
+
 export const deleteRoom = async (name: string): Promise<Room> => {
   const res = await fetch(`${DAILY_API_URL}/rooms/${name}`, {
     method: 'DELETE',


### PR DESCRIPTION
Issue: [Notion Task ⛑️ ](https://www.notion.so/29k/Early-Access-2794500652b34c64b0aff0dbbc53e0ab#17a217f9272640b4a8ef75c431e80e79)

### Description of the Change

When updating the session's start time, we need to update our third-party api for video calls with an updated expiry date.

