### PR TITLE
Lottie support in slides

### DIFF
--- a/client/src/common/components/LottiePlayer/LottiePlayer.tsx
+++ b/client/src/common/components/LottiePlayer/LottiePlayer.tsx
@@ -1,0 +1,86 @@
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+import AnimatedLottieView, {AnimatedLottieViewProps} from 'lottie-react-native';
+import {View, ViewStyle} from 'react-native';
+
+export type LottiePlayerProps = {
+  style?: ViewStyle;
+  source: AnimatedLottieViewProps['source'];
+  paused: boolean;
+  repeat: boolean;
+  duration: number;
+  onEnd?: () => void;
+};
+
+export type LottiePlayerHandle = {
+  seek: (seconds: number) => void;
+};
+
+// This component wraps Lottie and tries to mimic parts of the react-native-video props and imperative API
+const LottiePlayer = forwardRef<LottiePlayerHandle, LottiePlayerProps>(
+  ({style, source, paused, onEnd, duration = 60, repeat = false}, ref) => {
+    const lottieRef = useRef<AnimatedLottieView>(null);
+    const [progress, setProgress] = useState(0);
+
+    const togglePaused = useCallback((pause: boolean) => {
+      if (pause) {
+        lottieRef.current?.pause();
+      } else {
+        lottieRef.current?.resume();
+      }
+    }, []);
+
+    const seek = useCallback(
+      (seconds: number) => {
+        if (seconds === 0) {
+          // Setting progress to 0 doesn't work
+          lottieRef.current?.reset();
+        } else {
+          // No imperative API for seeking
+          setProgress(seconds / duration);
+        }
+        // Allways pause or resume after seek
+        togglePaused(paused);
+      },
+      [togglePaused, duration, paused],
+    );
+
+    const onAnimationFinish = useCallback(
+      (isCancelled: boolean) => {
+        if (!isCancelled && onEnd) {
+          onEnd();
+        }
+      },
+      [onEnd],
+    );
+
+    useImperativeHandle(ref, () => ({seek}), [seek]);
+
+    useEffect(() => {
+      togglePaused(paused);
+    }, [paused, togglePaused]);
+
+    return (
+      <View style={style}>
+        <AnimatedLottieView
+          onAnimationFinish={onAnimationFinish}
+          source={source}
+          speed={duration ? 60 / duration : 1}
+          loop={repeat}
+          autoPlay={!paused}
+          progress={progress}
+          resizeMode="contain"
+          ref={lottieRef}
+        />
+      </View>
+    );
+  },
+);
+
+export default LottiePlayer;

--- a/client/src/routes/Session/components/ContentControls/ContentControls.tsx
+++ b/client/src/routes/Session/components/ContentControls/ContentControls.tsx
@@ -117,12 +117,16 @@ const ContentControls: React.FC<ContentControlsProps> = ({
         {t('controls.prev')}
       </SlideButton>
       {slideState.current.type !== 'host' &&
-        !slideState.current.content?.video?.autoPlayLoop && (
+        !slideState.current.content?.video?.autoPlayLoop &&
+        !slideState.current.content?.lottie?.autoPlayLoop && (
           <MediaControls>
             <IconSlideButton
               small
               elevated
-              disabled={!slideState.current.content?.video}
+              disabled={
+                !slideState.current.content?.video &&
+                !slideState.current.content?.lottie
+              }
               variant="tertiary"
               Icon={Rewind}
               onPress={onResetPlayingPress}
@@ -131,7 +135,10 @@ const ContentControls: React.FC<ContentControlsProps> = ({
             <IconSlideButton
               small
               elevated
-              disabled={!slideState.current.content?.video}
+              disabled={
+                !slideState.current.content?.video &&
+                !slideState.current.content?.lottie
+              }
               variant="tertiary"
               Icon={
                 exerciseState.playing && !currentContentReachedEnd

--- a/client/src/routes/Session/components/DurationTimer/DurationTimer.tsx
+++ b/client/src/routes/Session/components/DurationTimer/DurationTimer.tsx
@@ -1,14 +1,10 @@
-import React, {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from 'react';
-import AnimatedLottieView from 'lottie-react-native';
+import React, {forwardRef} from 'react';
+
 import timer60s from '../../../../assets/animations/60s-timer.json';
-import {View, ViewStyle} from 'react-native';
+import {ViewStyle} from 'react-native';
+import LottiePlayer, {
+  LottiePlayerHandle,
+} from '../../../../common/components/LottiePlayer/LottiePlayer';
 
 type DurationTimerProps = {
   style?: ViewStyle;
@@ -16,57 +12,17 @@ type DurationTimerProps = {
   duration: number;
 };
 
-export type DurationTimerHandle = {
-  seek: (seconds: number) => void;
-};
-
-// This component wraps Lottie and tries to mimic parts of the react-native-video props and imperative API
-const DurationTimer = forwardRef<DurationTimerHandle, DurationTimerProps>(
+const DurationTimer = forwardRef<LottiePlayerHandle, DurationTimerProps>(
   ({style, paused, duration = 60}, ref) => {
-    const lottieRef = useRef<AnimatedLottieView>(null);
-    const [progress, setProgress] = useState(0);
-
-    const togglePaused = useCallback((pause: boolean) => {
-      if (pause) {
-        lottieRef.current?.pause();
-      } else {
-        lottieRef.current?.resume();
-      }
-    }, []);
-
-    const seek = useCallback(
-      (seconds: number) => {
-        if (seconds === 0) {
-          // Setting progress to 0 doesn't work
-          lottieRef.current?.reset();
-        } else {
-          // No imperative API for seeking
-          setProgress(seconds / duration);
-        }
-        // Allways pause or resume after seek
-        togglePaused(paused);
-      },
-      [togglePaused, duration, paused],
-    );
-
-    useImperativeHandle(ref, () => ({seek}), [seek]);
-
-    useEffect(() => {
-      togglePaused(paused);
-    }, [paused, togglePaused]);
-
     return (
-      <View style={style}>
-        <AnimatedLottieView
-          source={timer60s}
-          speed={duration ? 60 / duration : 1}
-          loop={false}
-          autoPlay={!paused}
-          progress={progress}
-          resizeMode="contain"
-          ref={lottieRef}
-        />
-      </View>
+      <LottiePlayer
+        style={style}
+        duration={duration}
+        ref={ref}
+        paused={paused}
+        source={timer60s}
+        repeat={false}
+      />
     );
   },
 );

--- a/client/src/routes/Session/components/Slides/Slides/Blocks/Lottie.tsx
+++ b/client/src/routes/Session/components/Slides/Slides/Blocks/Lottie.tsx
@@ -3,9 +3,7 @@ import styled from 'styled-components/native';
 import RNVideo, {OnLoadData} from 'react-native-video';
 
 import useSessionState from '../../../../state/state';
-import DurationTimer, {
-  DurationTimerHandle,
-} from '../../../DurationTimer/DurationTimer';
+import DurationTimer from '../../../DurationTimer/DurationTimer';
 import LPlayer, {
   LottiePlayerHandle,
 } from '../../../../../../common/components/LottiePlayer/LottiePlayer';
@@ -46,7 +44,7 @@ const Lottie: React.FC<LottieProps> = ({
 }) => {
   const lottieRef = useRef<LottiePlayerHandle>(null);
   const videoRef = useRef<RNVideo>(null);
-  const timerRef = useRef<DurationTimerHandle>(null);
+  const timerRef = useRef<LottiePlayerHandle>(null);
   const [audioDuration, setAudioDuration] = useState(0);
   const exerciseState = useSessionState(state => state.session?.exerciseState);
   const setCurrentContentReachedEnd = useSessionState(
@@ -130,9 +128,13 @@ const Lottie: React.FC<LottieProps> = ({
   const timer = useMemo(
     () =>
       durationTimer ? (
-        <Duration duration={duration} paused={paused} ref={timerRef} />
+        <Duration
+          duration={audioDuration > 0 ? audioDuration : duration}
+          paused={paused}
+          ref={timerRef}
+        />
       ) : null,
-    [durationTimer, paused, duration],
+    [durationTimer, paused, duration, audioDuration],
   );
 
   if (audioSource) {

--- a/client/src/routes/Session/components/Slides/Slides/Blocks/Lottie.tsx
+++ b/client/src/routes/Session/components/Slides/Slides/Blocks/Lottie.tsx
@@ -1,0 +1,178 @@
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import styled from 'styled-components/native';
+import RNVideo, {OnLoadData} from 'react-native-video';
+
+import useSessionState from '../../../../state/state';
+import DurationTimer, {
+  DurationTimerHandle,
+} from '../../../DurationTimer/DurationTimer';
+import LPlayer, {
+  LottiePlayerHandle,
+} from '../../../../../../common/components/LottiePlayer/LottiePlayer';
+import {VideoBase} from '../../../VideoBase/VideoBase';
+
+const LottiePlayer = styled(LPlayer)({
+  flex: 1,
+});
+
+const AudioPlayer = styled(VideoBase)({
+  display: 'none',
+});
+
+const Duration = styled(DurationTimer)({
+  position: 'absolute',
+  right: 22,
+  top: 16,
+  width: 30,
+  height: 30,
+});
+
+type LottieProps = {
+  source: {uri: string};
+  audioSource?: {uri: string};
+  active: boolean;
+  duration: number;
+  preview?: string;
+  autoPlayLoop?: boolean;
+  durationTimer?: boolean;
+};
+const Lottie: React.FC<LottieProps> = ({
+  active,
+  source,
+  audioSource,
+  duration,
+  autoPlayLoop = false,
+  durationTimer = false,
+}) => {
+  const lottieRef = useRef<LottiePlayerHandle>(null);
+  const videoRef = useRef<RNVideo>(null);
+  const timerRef = useRef<DurationTimerHandle>(null);
+  const [audioDuration, setAudioDuration] = useState(0);
+  const exerciseState = useSessionState(state => state.session?.exerciseState);
+  const setCurrentContentReachedEnd = useSessionState(
+    state => state.setCurrentContentReachedEnd,
+  );
+  const previousState = useRef({playing: false, timestamp: new Date()});
+
+  const seek = useCallback(
+    (seconds: number) => {
+      if (audioSource) {
+        videoRef.current?.seek(seconds);
+      } else {
+        lottieRef.current?.seek(seconds);
+      }
+
+      timerRef.current?.seek(seconds);
+    },
+    [audioSource],
+  );
+
+  useEffect(() => {
+    if (
+      active &&
+      !autoPlayLoop &&
+      (duration || audioDuration) &&
+      exerciseState
+    ) {
+      // Block is active, video and state is loaded
+      const playing = exerciseState.playing;
+      const timestamp = new Date(exerciseState.timestamp);
+
+      if (
+        timestamp > previousState.current.timestamp &&
+        previousState.current.playing === playing
+      ) {
+        // State is equal, but newer - reset to beginning
+        seek(0);
+      } else if (timestamp < previousState.current.timestamp && playing) {
+        // State is old - compensate time played
+        const timeDiff = (new Date().getTime() - timestamp.getTime()) / 1000;
+        const usedDuration = audioDuration > 0 ? audioDuration : duration;
+        if (timeDiff < usedDuration) {
+          // Do not seek passed video length
+          seek(timeDiff);
+        } else {
+          seek(usedDuration - 1);
+        }
+      }
+
+      // Update previous state
+      previousState.current = {
+        playing,
+        timestamp,
+      };
+    }
+  }, [
+    active,
+    autoPlayLoop,
+    duration,
+    audioDuration,
+    previousState,
+    exerciseState,
+    seek,
+  ]);
+
+  const onLoad = useCallback<(data: OnLoadData) => void>(
+    data => {
+      setAudioDuration(data.duration);
+    },
+    [setAudioDuration],
+  );
+
+  const onEnd = useCallback(() => {
+    if (!autoPlayLoop) {
+      setCurrentContentReachedEnd(true);
+    }
+  }, [setCurrentContentReachedEnd, autoPlayLoop]);
+
+  const paused = !active || (!exerciseState?.playing && !autoPlayLoop);
+
+  const timer = useMemo(
+    () =>
+      durationTimer ? (
+        <Duration duration={duration} paused={paused} ref={timerRef} />
+      ) : null,
+    [durationTimer, paused, duration],
+  );
+
+  if (audioSource) {
+    // If audio source is available we allways loop the animation
+    return (
+      <>
+        <AudioPlayer
+          source={audioSource}
+          audioOnly
+          ref={videoRef}
+          onLoad={onLoad}
+          onEnd={onEnd}
+          repeat={autoPlayLoop}
+          paused={paused}
+        />
+        <LottiePlayer
+          paused={paused}
+          source={source}
+          duration={duration}
+          ref={lottieRef}
+          repeat
+        />
+        {timer}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <LottiePlayer
+        paused={paused}
+        source={source}
+        duration={duration}
+        ref={lottieRef}
+        onEnd={onEnd}
+        repeat={autoPlayLoop}
+      />
+      {timer}
+    </>
+  );
+};
+
+export default Lottie;

--- a/client/src/routes/Session/components/Slides/Slides/Blocks/Video.tsx
+++ b/client/src/routes/Session/components/Slides/Slides/Blocks/Video.tsx
@@ -4,9 +4,8 @@ import RNVideo, {VideoProperties, OnLoadData} from 'react-native-video';
 
 import useSessionState from '../../../../state/state';
 import VideoBase from '../../../VideoBase/VideoBase';
-import DurationTimer, {
-  DurationTimerHandle,
-} from '../../../DurationTimer/DurationTimer';
+import DurationTimer from '../../../DurationTimer/DurationTimer';
+import {LottiePlayerHandle} from '../../../../../../common/components/LottiePlayer/LottiePlayer';
 
 const VideoPlayer = styled(VideoBase)({
   flex: 1,
@@ -41,7 +40,7 @@ const Video: React.FC<VideoProps> = ({
   durationTimer = false,
 }) => {
   const videoRef = useRef<RNVideo>(null);
-  const timerRef = useRef<DurationTimerHandle>(null);
+  const timerRef = useRef<LottiePlayerHandle>(null);
   const onEndRef = useRef<boolean>(false);
   const [duration, setDuration] = useState(0);
   const exerciseState = useSessionState(state => state.session?.exerciseState);

--- a/client/src/routes/Session/components/Slides/Slides/Content.tsx
+++ b/client/src/routes/Session/components/Slides/Slides/Content.tsx
@@ -14,6 +14,7 @@ import {
   Spacer8,
 } from '../../../../../common/components/Spacers/Spacer';
 import Text from './Blocks/Text';
+import Lottie from './Blocks/Lottie';
 
 const GraphicsWrapper = styled.View({
   flex: 1,
@@ -52,23 +53,50 @@ const Content: React.FC<ContentProps> = ({slide: {content = {}}, active}) => {
     [content?.image?.source],
   );
 
+  const lottieSource = useMemo(
+    () => ({uri: content?.lottie?.source ?? ''}),
+    [content?.lottie?.source],
+  );
+
+  const lottieAudioSource = useMemo(
+    () => (content?.lottie?.audio ? {uri: content.lottie.audio} : undefined),
+    [content?.lottie?.audio],
+  );
+
+  const lottieDuration = useMemo(
+    () => parseInt(content.lottie?.duration ?? '60', 10),
+    [content.lottie?.duration],
+  );
+
   return (
     <>
       <Spacer12 />
-      {!content.video && !content.image && (
+      {!content.video && !content.image && !content.lottie && (
         <TextWrapper>
           {content.heading && <Heading>{content.heading}</Heading>}
           {content.text && <Text>{content.text}</Text>}
         </TextWrapper>
       )}
-      {(content.video || content.image) && content.heading && (
-        <Heading>{content.heading}</Heading>
-      )}
-      {(content.video || content.image) && content.text && (
+      {(content.video || content.image || content.lottie) &&
+        content.heading && <Heading>{content.heading}</Heading>}
+      {(content.video || content.image || content.lottie) && content.text && (
         <Text>{content.text}</Text>
       )}
 
-      {content.video ? (
+      {content.lottie ? (
+        <GraphicsWrapper>
+          <Spacer8 />
+          <Lottie
+            source={lottieSource}
+            audioSource={lottieAudioSource}
+            active={active}
+            duration={lottieDuration}
+            autoPlayLoop={content.lottie.autoPlayLoop}
+            durationTimer={content.lottie.durationTimer}
+          />
+          <Spacer8 />
+        </GraphicsWrapper>
+      ) : content.video ? (
         <GraphicsWrapper>
           <Spacer8 />
           <VideoWrapper>

--- a/cms/src/fields/common.ts
+++ b/cms/src/fields/common.ts
@@ -77,6 +77,34 @@ export const IMAGE_FIELD: CmsFieldBase & CmsFieldObject = {
   ],
 };
 
+export const LOTTE_FIELD: CmsFieldBase & CmsFieldObject = {
+  label: '💃 Lottie',
+  name: 'lottie',
+  widget: 'object',
+  collapsed: true,
+  required: false,
+  i18n: true,
+  fields: [
+    {
+      label: '📃 Description',
+      name: 'description',
+      widget: 'string',
+      required: false,
+      i18n: true,
+    },
+    {
+      label: '💃 Lottie file',
+      name: 'source',
+      widget: 'file',
+      required: false,
+      i18n: true,
+      allow_multiple: false,
+      media_library: CLOUDINARY_IMAGE_CONFIG,
+    },
+    {...DURATION_FIELD, hint: 'Duration in seconds', required: false},
+  ],
+};
+
 export const VIDEO_FIELD: CmsFieldBase & CmsFieldObject = {
   label: '🎥 Video',
   name: 'video',
@@ -130,6 +158,17 @@ export const VIDEO_FIELD_WITH_AUDIO: CmsFieldBase & CmsFieldObject = {
     {
       ...AUDIO_FIELD,
       hint: 'This will override the audio of the video. Video will automatically loop while playing.',
+    },
+  ],
+};
+
+export const LOTTIE_FIELD_WITH_AUDIO: CmsFieldBase & CmsFieldObject = {
+  ...LOTTE_FIELD,
+  fields: [
+    ...LOTTE_FIELD.fields,
+    {
+      ...AUDIO_FIELD,
+      hint: 'Animation will automatically loop while playing.',
     },
   ],
 };

--- a/cms/src/fields/slides.ts
+++ b/cms/src/fields/slides.ts
@@ -5,7 +5,12 @@ import {
   CmsFieldList,
 } from 'netlify-cms-core';
 
-import {IMAGE_FIELD, VIDEO_FIELD_WITH_AUDIO} from './common';
+import {
+  IMAGE_FIELD,
+  LOTTE_FIELD,
+  LOTTIE_FIELD_WITH_AUDIO,
+  VIDEO_FIELD_WITH_AUDIO,
+} from './common';
 
 export const SLIDE_TYPES = {
   HOST: 'host',
@@ -56,6 +61,28 @@ const CONTENT_VIDEO_FIELD: CmsFieldBase & CmsFieldObject = {
   ],
 };
 
+const CONTENT_LOTTIE_FIELD: CmsFieldBase & CmsFieldObject = {
+  ...LOTTIE_FIELD_WITH_AUDIO,
+  hint: 'Overrides video',
+  fields: [
+    {
+      label: '🔁 Auto Play & Loop',
+      name: 'autoPlayLoop',
+      hint: 'This automatically plays and loops the video. Play controls will be disabled.',
+      required: false,
+      widget: 'boolean',
+    },
+    {
+      label: '⏱️ Duration timer',
+      name: 'durationTimer',
+      hint: 'This shows a duration timer in the top right corner. Useful for stand-alone audio.',
+      required: false,
+      widget: 'boolean',
+    },
+    ...LOTTIE_FIELD_WITH_AUDIO.fields,
+  ],
+};
+
 const CONTENT_FIELDS: Array<CmsField> = [
   {
     label: '◾️ Heading',
@@ -71,6 +98,7 @@ const CONTENT_FIELDS: Array<CmsField> = [
   },
   IMAGE_FIELD,
   CONTENT_VIDEO_FIELD,
+  CONTENT_LOTTIE_FIELD,
 ];
 
 export const HOST_SLIDE: CmsFieldBase & CmsFieldObject = {

--- a/shared/src/types/generated/Exercise.ts
+++ b/shared/src/types/generated/Exercise.ts
@@ -69,11 +69,21 @@ export interface ExerciseSlideContentSlideContentVideo {
   audio?: string;
 }
 
+export interface ExerciseSlideContentSlideContentLottie {
+  autoPlayLoop?: boolean;
+  durationTimer?: boolean;
+  description?: string;
+  source?: string;
+  duration?: string;
+  audio?: string;
+}
+
 export interface ExerciseSlideContentSlideContent {
   heading?: string;
   text?: string;
   image?: ExerciseSlideContentSlideContentImage;
   video?: ExerciseSlideContentSlideContentVideo;
+  lottie?: ExerciseSlideContentSlideContentLottie;
 }
 
 export interface ExerciseSlideReflectionSlideHostNote {
@@ -94,11 +104,21 @@ export interface ExerciseSlideReflectionSlideContentVideo {
   audio?: string;
 }
 
+export interface ExerciseSlideReflectionSlideContentLottie {
+  autoPlayLoop?: boolean;
+  durationTimer?: boolean;
+  description?: string;
+  source?: string;
+  duration?: string;
+  audio?: string;
+}
+
 export interface ExerciseSlideReflectionSlideContent {
   heading?: string;
   text?: string;
   image?: ExerciseSlideReflectionSlideContentImage;
   video?: ExerciseSlideReflectionSlideContentVideo;
+  lottie?: ExerciseSlideReflectionSlideContentLottie;
 }
 
 export interface ExerciseSlideSharingSlideHostNote {
@@ -119,11 +139,21 @@ export interface ExerciseSlideSharingSlideContentVideo {
   audio?: string;
 }
 
+export interface ExerciseSlideSharingSlideContentLottie {
+  autoPlayLoop?: boolean;
+  durationTimer?: boolean;
+  description?: string;
+  source?: string;
+  duration?: string;
+  audio?: string;
+}
+
 export interface ExerciseSlideSharingSlideContent {
   heading?: string;
   text?: string;
   image?: ExerciseSlideSharingSlideContentImage;
   video?: ExerciseSlideSharingSlideContentVideo;
+  lottie?: ExerciseSlideSharingSlideContentLottie;
 }
 
 export interface ExerciseSlideHostSlideHostNote {
@@ -154,7 +184,7 @@ export interface ExerciseSlideHostSlide {
 }
 
 export interface Exercise {
-  id?: any;
+  id: any;
   name: string;
   duration: string;
   published: boolean;


### PR DESCRIPTION
Adds support for using lottie files as slides and builds on @gewfy excellent work on mimicking `react-native-video` api and makes `Blocks/Lottie` and `Blocks/Video` very similar
