### PR TITLE
Only recreate user when getIdToken fails with revoked or expired

### DIFF
--- a/client/src/lib/apiClient/apiClient.spec.ts
+++ b/client/src/lib/apiClient/apiClient.spec.ts
@@ -66,10 +66,10 @@ describe('apiClient', () => {
     });
   });
 
-  it('recreates user if authorization header from server fails', async () => {
+  it('recreates user if authorization header from server fails with auth/id-token-expired', async () => {
     (auth().currentUser?.getIdToken as jest.Mock)
-      .mockRejectedValueOnce(new Error('Failed to get token'))
-      .mockRejectedValueOnce(new Error('Failed to get token'))
+      .mockRejectedValueOnce({code: 'auth/id-token-expired'})
+      .mockRejectedValueOnce({code: 'auth/id-token-expired'})
       .mockResolvedValueOnce('some-authorization-token');
 
     await apiClient('/some-path');
@@ -90,6 +90,51 @@ describe('apiClient', () => {
         Authorization: 'bearer some-authorization-token',
       },
     });
+  });
+
+  it('recreates user if authorization header from server fails with auth/id-token-revoked', async () => {
+    (auth().currentUser?.getIdToken as jest.Mock)
+      .mockRejectedValueOnce({code: 'auth/id-token-expired'})
+      .mockRejectedValueOnce({code: 'auth/id-token-expired'})
+      .mockResolvedValueOnce('some-authorization-token');
+
+    await apiClient('/some-path');
+
+    expect(auth().currentUser?.getIdToken).toHaveBeenCalledTimes(3);
+    expect(auth().currentUser?.getIdToken).toHaveBeenCalledWith();
+    expect(auth().currentUser?.getIdToken).toHaveBeenCalledWith(true);
+
+    expect(auth().signOut).toHaveBeenCalledTimes(1);
+    expect(auth().signInAnonymously).toHaveBeenCalledTimes(1);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('some-api-endpoint/some-path', {
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept-Language': 'en',
+        'X-Correlation-ID': expect.any(String),
+        Authorization: 'bearer some-authorization-token',
+      },
+    });
+  });
+
+  it('thows if authorization header from server fails on other errors', async () => {
+    (auth().currentUser?.getIdToken as jest.Mock)
+      .mockRejectedValueOnce(new Error('Failed to get token'))
+      .mockRejectedValueOnce({code: 'auth/network-request-failed'});
+
+    await expect(apiClient('/some-path')).rejects.toThrow(
+      new Error('Failed to get user token'),
+    );
+
+    expect(auth().currentUser?.getIdToken).toHaveBeenCalledTimes(2);
+    expect(auth().currentUser?.getIdToken).toHaveBeenCalledWith();
+    expect(auth().currentUser?.getIdToken).toHaveBeenCalledWith(true);
+
+    expect(auth().signOut).toHaveBeenCalledTimes(0);
+    expect(auth().signInAnonymously).toHaveBeenCalledTimes(0);
+
+    expect(fetchMock).toHaveBeenCalledTimes(0);
   });
 
   it('recreates user if no user is signed in', async () => {
@@ -204,25 +249,6 @@ describe('apiClient', () => {
 
     expect(auth().signOut).toHaveBeenCalledTimes(1);
     expect(auth().signInAnonymously).toHaveBeenCalledTimes(1);
-  });
-
-  it('thows if authorization header from server fails on network error', async () => {
-    (auth().currentUser?.getIdToken as jest.Mock)
-      .mockRejectedValueOnce(new Error('Failed to get token'))
-      .mockRejectedValueOnce({code: 'auth/network-request-failed'});
-
-    await expect(apiClient('/some-path')).rejects.toThrow(
-      new Error('Network request failed'),
-    );
-
-    expect(auth().currentUser?.getIdToken).toHaveBeenCalledTimes(2);
-    expect(auth().currentUser?.getIdToken).toHaveBeenCalledWith();
-    expect(auth().currentUser?.getIdToken).toHaveBeenCalledWith(true);
-
-    expect(auth().signOut).toHaveBeenCalledTimes(0);
-    expect(auth().signInAnonymously).toHaveBeenCalledTimes(0);
-
-    expect(fetchMock).toHaveBeenCalledTimes(0);
   });
 
   it('allows overriding Content-Type and authorization', async () => {

--- a/client/src/lib/apiClient/apiClient.ts
+++ b/client/src/lib/apiClient/apiClient.ts
@@ -36,12 +36,15 @@ const getAuthorizationToken = async (): Promise<string> => {
       } catch (error) {
         const firebaseError =
           error as FirebaseAuthTypes.NativeFirebaseAuthError;
-        if (firebaseError.code === 'auth/network-request-failed') {
-          throw new Error('Network request failed');
+        if (
+          firebaseError.code === 'auth/id-token-expired' ||
+          firebaseError.code === 'auth/id-token-revoked'
+        ) {
+          await recreateUser();
+          return await getAuthorizationToken();
         }
 
-        await recreateUser();
-        return await getAuthorizationToken();
+        throw new Error('Failed to get user token', {cause: error});
       }
     }
   }


### PR DESCRIPTION
Flip recreation of user on expected errors revoked or expired when fetching id token

@gewfy we swallow all promise rejections so the user has no way of knowing there was an error, should we fix that now?  