### PR TITLE
Update host notes nav button

### DIFF
--- a/client/src/routes/Session/components/HostNotes/HostNotes.tsx
+++ b/client/src/routes/Session/components/HostNotes/HostNotes.tsx
@@ -39,6 +39,10 @@ import {
 } from '../../../../common/components/Spacers/Spacer';
 import ToggleButton from './ToggleButton';
 
+const NotesNavBtn = styled(NavButton)(({disabled}) => ({
+  opacity: disabled ? 0 : 1,
+}));
+
 const ShadowWrapper = styled.View({
   ...SETTINGS.BOXSHADOW,
   borderBottomRightRadius: SETTINGS.BORDER_RADIUS.CARDS, // adding borderRadius somehow fixes elevation not showing on Android
@@ -205,7 +209,7 @@ const HostNotes: React.FC<HostNotesProps> = ({
               />
               <GestureRecognizer onSwipeUp={() => setShowNotes(false)}>
                 <Navigation>
-                  <NavButton
+                  <NotesNavBtn
                     onPress={() =>
                       setScroll({
                         index: scroll.index - 1,
@@ -216,7 +220,7 @@ const HostNotes: React.FC<HostNotesProps> = ({
                     disabled={scroll.index <= 0}
                   />
                   <Body14>{`${scroll.index + 1} / ${notes.length}`}</Body14>
-                  <NavButton
+                  <NotesNavBtn
                     onPress={() =>
                       setScroll({
                         index: scroll.index + 1,

--- a/client/src/routes/Session/components/HostNotes/NavButton.tsx
+++ b/client/src/routes/Session/components/HostNotes/NavButton.tsx
@@ -4,8 +4,14 @@ import IconButton, {
   IconButtonProps,
 } from '../../../../common/components/Buttons/IconButton/IconButton';
 
-const NavButton: React.FC<IconButtonProps> = ({Icon, onPress, disabled}) => (
+const NavButton: React.FC<IconButtonProps> = ({
+  Icon,
+  onPress,
+  disabled,
+  style,
+}) => (
   <IconButton
+    style={style}
     onPress={onPress}
     Icon={Icon}
     noBackground


### PR DESCRIPTION
Any reason why we don't duplicate the same behavior we have for slides nav buttons on the host notes?

https://user-images.githubusercontent.com/7523828/208165936-f7864182-1d3a-4be0-844e-55fac857fd2d.mp4

