### PR TITLE
Fix issue with modals being clipped on input focus

### DIFF
--- a/client/src/lib/navigation/ModalStack.tsx
+++ b/client/src/lib/navigation/ModalStack.tsx
@@ -56,6 +56,11 @@ const modalScreenOptions: BottomSheetNavigationOptions = {
     left: 0,
     right: 0,
   },
+  /*
+    Fixes issues with modals being clipped when focusing on input fields
+    https://github.com/gorhom/react-native-bottom-sheet/issues/618
+  */
+  android_keyboardInputMode: 'adjustResize',
 };
 
 const ModalStack = () => {
@@ -64,7 +69,8 @@ const ModalStack = () => {
   const sheetModalScreenOptions = useMemo(
     () => ({
       ...modalScreenOptions,
-      snapPoints: ['50%', '75%', '100%'],
+      // Please note - Having a fixed snap point as first value improves keyboard input focus on Android
+      snapPoints: [380, '75%', '100%'],
       style: {
         // Using margin instead of topInset to make the shadow visible when snapped at 100%
         marginTop: top,
@@ -76,10 +82,20 @@ const ModalStack = () => {
     [top],
   );
 
+  const shortSheetModalScreenOptions = useMemo(
+    () => ({
+      ...sheetModalScreenOptions,
+      // Please note - Having a fixed snap point as first value improves keyboard input focus on Android
+      snapPoints: [250, '75%', '100%'],
+    }),
+    [sheetModalScreenOptions],
+  );
+
   const tallSheetModalScreenOptions = useMemo(
     () => ({
       ...sheetModalScreenOptions,
-      snapPoints: ['75%', '100%'],
+      // Please note - Having a fixed snap point as first value improves keyboard input focus on Android
+      snapPoints: [600, '100%'],
     }),
     [sheetModalScreenOptions],
   );
@@ -107,7 +123,11 @@ const ModalStack = () => {
       <Group screenOptions={sheetModalScreenOptions}>
         <Screen name={'SessionModal'} component={SessionModal} />
         <Screen name={'CreateSessionModal'} component={CreateSessionModal} />
-        <Screen name={'UpgradeAccountModal'} component={UpgradeAccountModal} />
+        <Screen
+          name={'UpgradeAccountModal'}
+          component={UpgradeAccountModal}
+          options={shortSheetModalScreenOptions}
+        />
         <Screen
           name={'SessionUnavailableModal'}
           component={SessionUnavailableModal}
@@ -118,7 +138,7 @@ const ModalStack = () => {
           component={ProfileSettingsModal}
           options={tallSheetModalScreenOptions}
         />
-        <Screen name={'SignInModal'} component={SignInModal} />
+
         <Screen name={'ContributorsModal'} component={ContributorsModal} />
         <Screen name={'PartnersModal'} component={PartnersModal} />
         <Screen name={'DeveloperModal'} component={DeveloperModal} />
@@ -127,6 +147,11 @@ const ModalStack = () => {
 
       <Group screenOptions={cardModalScreenOptions}>
         <Screen name={'AddSessionModal'} component={AddSessionModal} />
+        <Screen
+          name={'SignInModal'}
+          component={SignInModal}
+          options={shortSheetModalScreenOptions}
+        />
       </Group>
     </Navigator>
   );


### PR DESCRIPTION
Fixes issues where sheet modals gets clipped when focusing/bluring inputs on android. Also see https://github.com/gorhom/react-native-bottom-sheet/issues/618

# Before
https://user-images.githubusercontent.com/474066/209643082-1358a9c7-0afc-41a2-b33d-4b45ce565eac.mov

# After
https://user-images.githubusercontent.com/474066/209642847-77ac1826-df02-410e-8b92-6a7718263eb6.mov