### PR TITLE
Show host controls on top

### DIFF
--- a/client/src/routes/Session/Session.tsx
+++ b/client/src/routes/Session/Session.tsx
@@ -57,6 +57,7 @@ const ExerciseControl = styled(ContentControls)({
   bottom: SPACINGS.SIXTEEN,
   left: SPACINGS.SIXTEEN,
   right: SPACINGS.SIXTEEN,
+  zIndex: 1000,
 });
 
 const SessionControls = styled.View({


### PR DESCRIPTION
Need to set zIndex to a higher number than hon slides for host controls to show on android
