### PR TITLE
Better abstraction for checking and alerting about app permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can get early access to our open beta through iOS TestFlight and Android Pla
 
 ## Join Our Community
 
-Join our [Slack community](https://community.29k.org) if you need help, want to chat, or are thinking of a new feature. 
+Join our [Slack community](https://community.29k.org) if you need help, want to chat, or are thinking of a new feature.
 
 ## Documentation
 

--- a/client/__mocks__/react-native.js
+++ b/client/__mocks__/react-native.js
@@ -16,11 +16,17 @@ export const Alert = {
   alert: jest.fn(),
 };
 
+export const Linking = {
+  openURL: jest.fn(),
+  openSettings: jest.fn(),
+};
+
 export default Object.setPrototypeOf(
   {
     Platform,
     AppState,
     Alert,
+    Linking,
   },
   ReactNative,
 );

--- a/client/src/routes/Session/ChangingRoom.tsx
+++ b/client/src/routes/Session/ChangingRoom.tsx
@@ -6,7 +6,7 @@ import {
   useRoute,
 } from '@react-navigation/native';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {ActivityIndicator, Alert, Linking, Platform} from 'react-native';
+import {ActivityIndicator, Platform} from 'react-native';
 import styled from 'styled-components/native';
 import {useTranslation} from 'react-i18next';
 import {DailyMediaView} from '@daily-co/react-native-daily-js';
@@ -47,6 +47,7 @@ import useUser from '../../lib/user/hooks/useUser';
 import Image from '../../common/components/Image/Image';
 import useSubscribeToSessionIfFocused from './hooks/useSusbscribeToSessionIfFocused';
 import useLogSessionMetricEvents from './hooks/useLogSessionMetricEvents';
+import useCheckPermissions from './hooks/useCheckPermissions';
 
 const Wrapper = styled.KeyboardAvoidingView.attrs({
   behavior: Platform.select({ios: 'padding', android: undefined}),
@@ -110,15 +111,8 @@ const ChangingRoom = () => {
         SessionStackProps & TabNavigatorProps & ModalStackProps
       >
     >();
-  const {
-    toggleAudio,
-    toggleVideo,
-    setUserName,
-    joinMeeting,
-    preJoinMeeting,
-    hasCameraPermissions,
-    hasMicrophonePermissions,
-  } = useContext(DailyContext);
+  const {toggleAudio, toggleVideo, setUserName, joinMeeting, preJoinMeeting} =
+    useContext(DailyContext);
 
   const session = useSessionState(state => state.session);
   const {
@@ -133,6 +127,11 @@ const ChangingRoom = () => {
   const user = useUser();
   const [localUserName, setLocalUserName] = useState(user?.displayName ?? '');
   const {logSessionMetricEvent} = useLogSessionMetricEvents();
+  const {
+    checkJoinPermissions,
+    checkCameraPermissions,
+    checkMicrophonePermissions,
+  } = useCheckPermissions();
 
   const hasAudio = Boolean(me?.audioTrack);
   const hasVideo = Boolean(me?.videoTrack);
@@ -171,83 +170,22 @@ const ChangingRoom = () => {
     }
   }, [setJoiningMeeting, sessionId, session?.started, joinMeeting, navigate]);
 
-  const permissionsAlert = useCallback(
-    () =>
-      Alert.alert(
-        t('permissionsAlert.join.title'),
-        t('permissionsAlert.join.message'),
-        [
-          {
-            text: t('permissionsAlert.join.dismiss'),
-            onPress: join,
-          },
-          {
-            style: 'cancel',
-            text: t('permissionsAlert.join.confirm'),
-            onPress: () => Linking.openSettings(),
-          },
-        ],
-      ),
-    [t, join],
-  );
-
   const joinPress = useCallback(() => {
     setUserName(localUserName);
-    if (hasCameraPermissions() && hasMicrophonePermissions()) {
-      join();
-    } else {
-      permissionsAlert();
-    }
-  }, [
-    localUserName,
-    setUserName,
-    hasCameraPermissions,
-    hasMicrophonePermissions,
-    join,
-    permissionsAlert,
-  ]);
+    checkJoinPermissions(join);
+  }, [localUserName, setUserName, checkJoinPermissions, join]);
 
   const toggleAudioPress = useCallback(() => {
-    if (hasMicrophonePermissions()) {
+    checkMicrophonePermissions(() => {
       toggleAudio(!hasAudio);
-    } else {
-      Alert.alert(
-        t('permissionsAlert.microphone.title'),
-        t('permissionsAlert.microphone.message'),
-        [
-          {
-            text: t('permissionsAlert.microphone.dismiss'),
-          },
-          {
-            style: 'cancel',
-            text: t('permissionsAlert.microphone.confirm'),
-            onPress: () => Linking.openSettings(),
-          },
-        ],
-      );
-    }
-  }, [t, hasMicrophonePermissions, toggleAudio, hasAudio]);
+    });
+  }, [checkMicrophonePermissions, toggleAudio, hasAudio]);
 
   const toggleVideoPress = useCallback(() => {
-    if (hasCameraPermissions()) {
+    checkCameraPermissions(() => {
       toggleVideo(!hasVideo);
-    } else {
-      Alert.alert(
-        t('permissionsAlert.camera.title'),
-        t('permissionsAlert.camera.message'),
-        [
-          {
-            text: t('permissionsAlert.camera.dismiss'),
-          },
-          {
-            style: 'cancel',
-            text: t('permissionsAlert.camera.confirm'),
-            onPress: () => Linking.openSettings(),
-          },
-        ],
-      );
-    }
-  }, [t, hasCameraPermissions, toggleVideo, hasVideo]);
+    });
+  }, [checkCameraPermissions, toggleVideo, hasVideo]);
 
   return (
     <Screen onPressBack={goBack}>

--- a/client/src/routes/Session/Session.tsx
+++ b/client/src/routes/Session/Session.tsx
@@ -46,7 +46,7 @@ import useSubscribeToSessionIfFocused from './hooks/useSusbscribeToSessionIfFocu
 import useExerciseTheme from './hooks/useExerciseTheme';
 import useExerciseById from '../../lib/content/hooks/useExerciseById';
 import useLogSessionMetricEvents from './hooks/useLogSessionMetricEvents';
-import {Alert, Linking} from 'react-native';
+import useCheckPermissions from './hooks/useCheckPermissions';
 
 const Spotlight = styled.View({
   aspectRatio: '0.9375',
@@ -92,8 +92,6 @@ const StyledHangUpIcon = () => <HangUpIcon fill={COLORS.ACTIVE} />;
 
 const Session = () => {
   const {
-    hasMicrophonePermissions,
-    hasCameraPermissions,
     setUserData,
     toggleAudio,
     toggleVideo,
@@ -120,6 +118,8 @@ const Session = () => {
   const {logSessionMetricEvent, conditionallyLogCompleteSessionMetricEvent} =
     useLogSessionMetricEvents();
   const {leaveSessionWithConfirm} = useLeaveSession();
+  const {checkCameraPermissions, checkMicrophonePermissions} =
+    useCheckPermissions();
   const user = useUser();
 
   const hasAudio = Boolean(me?.audioTrack);
@@ -159,46 +159,16 @@ const Session = () => {
   }, [setUserData, setSubscribeToAllTracks, user?.photoURL]);
 
   const toggleAudioPress = useCallback(() => {
-    if (hasMicrophonePermissions()) {
+    checkMicrophonePermissions(() => {
       toggleAudio(!hasAudio);
-    } else {
-      Alert.alert(
-        t('permissionsAlert.microphone.title'),
-        t('permissionsAlert.microphone.message'),
-        [
-          {
-            text: t('permissionsAlert.microphone.dismiss'),
-          },
-          {
-            style: 'cancel',
-            text: t('permissionsAlert.microphone.confirm'),
-            onPress: () => Linking.openSettings(),
-          },
-        ],
-      );
-    }
-  }, [t, hasMicrophonePermissions, toggleAudio, hasAudio]);
+    });
+  }, [checkMicrophonePermissions, toggleAudio, hasAudio]);
 
   const toggleVideoPress = useCallback(() => {
-    if (hasCameraPermissions()) {
+    checkCameraPermissions(() => {
       toggleVideo(!hasVideo);
-    } else {
-      Alert.alert(
-        t('permissionsAlert.camera.title'),
-        t('permissionsAlert.camera.message'),
-        [
-          {
-            text: t('permissionsAlert.camera.dismiss'),
-          },
-          {
-            style: 'cancel',
-            text: t('permissionsAlert.camera.confirm'),
-            onPress: () => Linking.openSettings(),
-          },
-        ],
-      );
-    }
-  }, [t, hasCameraPermissions, toggleVideo, hasVideo]);
+    });
+  }, [checkCameraPermissions, toggleVideo, hasVideo]);
 
   return (
     <Screen backgroundColor={theme?.backgroundColor}>

--- a/client/src/routes/Session/hooks/useCheckPermissions.spec.ts
+++ b/client/src/routes/Session/hooks/useCheckPermissions.spec.ts
@@ -1,0 +1,303 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {useTranslation} from 'react-i18next';
+import {Alert, Linking} from 'react-native';
+import useCheckPermissions from './useCheckPermissions';
+
+const mockAlert = Alert.alert as jest.Mock;
+const mockOpenSettings = Linking.openSettings as jest.Mock;
+
+jest.mock('../../../lib/daily/DailyProvider', () => ({
+  DailyContext: jest.fn(),
+}));
+
+const mockHasCameraPermissions = jest.fn();
+const mockHasMicrophonePermissions = jest.fn();
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn(() => ({
+    hasCameraPermissions: mockHasCameraPermissions,
+    hasMicrophonePermissions: mockHasMicrophonePermissions,
+  })),
+}));
+
+const mockRestartApp = jest.fn();
+jest.mock(
+  '../../../lib/codePush/hooks/useRestartApp',
+  () => () => mockRestartApp,
+);
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useCheckPermissions', () => {
+  const {t} = useTranslation();
+  (t as unknown as jest.Mock).mockReturnValue('Some translation');
+
+  describe('checkCameraPermissions', () => {
+    it('runs onGranted callback if permissions are given', async () => {
+      const {result} = renderHook(() => useCheckPermissions());
+
+      mockHasCameraPermissions.mockReturnValue(true);
+
+      const onGranted = jest.fn();
+      const onDismiss = jest.fn();
+      await result.current.checkCameraPermissions(onGranted, onDismiss);
+
+      expect(onGranted).toHaveBeenCalledTimes(1);
+      expect(onDismiss).toHaveBeenCalledTimes(0);
+    });
+
+    it('triggers alert if permissions are denied', () => {
+      const {result} = renderHook(() => useCheckPermissions());
+
+      mockHasCameraPermissions.mockReturnValue(false);
+
+      const onGranted = jest.fn();
+      const onDismiss = jest.fn();
+      result.current.checkCameraPermissions(onGranted, onDismiss);
+
+      expect(mockAlert).toHaveBeenCalledTimes(1);
+      expect(mockAlert).toHaveBeenCalledWith(
+        'Some translation',
+        'Some translation',
+        [
+          {
+            onPress: expect.any(Function),
+            text: 'Some translation',
+          },
+          {
+            onPress: expect.any(Function),
+            style: 'cancel',
+            text: 'Some translation',
+          },
+        ],
+      );
+      expect(onGranted).toHaveBeenCalledTimes(0);
+      expect(onDismiss).toHaveBeenCalledTimes(0);
+    });
+
+    it('triggers onDismiss if permissions are denied and user dismiss', async () => {
+      mockAlert.mockImplementationOnce((header, text, config) => {
+        // Run the dimiss action
+        config[0].onPress();
+      });
+
+      const {result} = renderHook(() => useCheckPermissions());
+
+      mockHasCameraPermissions.mockReturnValue(false);
+
+      const onGranted = jest.fn();
+      const onDismiss = jest.fn();
+      await result.current.checkCameraPermissions(onGranted, onDismiss);
+
+      expect(onGranted).toHaveBeenCalledTimes(0);
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens settings and restarts app if permissions are denied and user confirms', async () => {
+      mockAlert.mockImplementationOnce((header, text, config) => {
+        // Run the confirm action
+        config[1].onPress();
+      });
+
+      const {result} = renderHook(() => useCheckPermissions());
+
+      mockHasCameraPermissions.mockReturnValue(false);
+
+      const onGranted = jest.fn();
+      const onDismiss = jest.fn();
+      await result.current.checkCameraPermissions(onGranted, onDismiss);
+
+      expect(mockOpenSettings).toHaveBeenCalledTimes(1);
+      expect(mockRestartApp).toHaveBeenCalledTimes(1);
+      expect(onGranted).toHaveBeenCalledTimes(0);
+      expect(onDismiss).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('checkMicrophonePermissions', () => {
+    it('runs onGranted callback if permissions are given', async () => {
+      const {result} = renderHook(() => useCheckPermissions());
+
+      mockHasMicrophonePermissions.mockReturnValue(true);
+
+      const onGranted = jest.fn();
+      const onDismiss = jest.fn();
+      await result.current.checkMicrophonePermissions(onGranted, onDismiss);
+
+      expect(onGranted).toHaveBeenCalledTimes(1);
+      expect(onDismiss).toHaveBeenCalledTimes(0);
+    });
+
+    it('triggers alert if permissions are denied', () => {
+      const {result} = renderHook(() => useCheckPermissions());
+
+      mockHasMicrophonePermissions.mockReturnValue(false);
+
+      const onGranted = jest.fn();
+      const onDismiss = jest.fn();
+      result.current.checkMicrophonePermissions(onGranted, onDismiss);
+
+      expect(mockAlert).toHaveBeenCalledTimes(1);
+      expect(mockAlert).toHaveBeenCalledWith(
+        'Some translation',
+        'Some translation',
+        [
+          {
+            onPress: expect.any(Function),
+            text: 'Some translation',
+          },
+          {
+            onPress: expect.any(Function),
+            style: 'cancel',
+            text: 'Some translation',
+          },
+        ],
+      );
+      expect(onGranted).toHaveBeenCalledTimes(0);
+      expect(onDismiss).toHaveBeenCalledTimes(0);
+    });
+
+    it('triggers onDismiss if permissions are denied and user dismiss', async () => {
+      mockAlert.mockImplementationOnce((header, text, config) => {
+        // Run the dimiss action
+        config[0].onPress();
+      });
+
+      const {result} = renderHook(() => useCheckPermissions());
+
+      mockHasMicrophonePermissions.mockReturnValue(false);
+
+      const onGranted = jest.fn();
+      const onDismiss = jest.fn();
+      await result.current.checkMicrophonePermissions(onGranted, onDismiss);
+
+      expect(onGranted).toHaveBeenCalledTimes(0);
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens settings and restarts app if permissions are denied and user confirms', async () => {
+      mockAlert.mockImplementationOnce((header, text, config) => {
+        // Run the confirm action
+        config[1].onPress();
+      });
+
+      const {result} = renderHook(() => useCheckPermissions());
+
+      mockHasMicrophonePermissions.mockReturnValue(false);
+
+      const onGranted = jest.fn();
+      const onDismiss = jest.fn();
+      await result.current.checkMicrophonePermissions(onGranted, onDismiss);
+
+      expect(mockOpenSettings).toHaveBeenCalledTimes(1);
+      expect(mockRestartApp).toHaveBeenCalledTimes(1);
+      expect(onGranted).toHaveBeenCalledTimes(0);
+      expect(onDismiss).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('checkJoinPermissions', () => {
+    it('runs onGranted callback if permissions are given', async () => {
+      const {result} = renderHook(() => useCheckPermissions());
+
+      mockHasCameraPermissions.mockReturnValue(true);
+      mockHasMicrophonePermissions.mockReturnValue(true);
+
+      const onGranted = jest.fn();
+      const onDismiss = jest.fn();
+      await result.current.checkJoinPermissions(onGranted, onDismiss);
+
+      expect(onGranted).toHaveBeenCalledTimes(1);
+      expect(onDismiss).toHaveBeenCalledTimes(0);
+    });
+
+    it('triggers alert if any of the permissions are denied', () => {
+      const {result} = renderHook(() => useCheckPermissions());
+
+      mockHasCameraPermissions.mockReturnValue(true);
+      mockHasMicrophonePermissions.mockReturnValue(false);
+
+      const onGranted = jest.fn();
+      const onDismiss = jest.fn();
+      result.current.checkJoinPermissions(onGranted, onDismiss);
+
+      expect(mockAlert).toHaveBeenCalledTimes(1);
+      expect(mockAlert).toHaveBeenCalledWith(
+        'Some translation',
+        'Some translation',
+        [
+          {
+            onPress: expect.any(Function),
+            text: 'Some translation',
+          },
+          {
+            onPress: expect.any(Function),
+            style: 'cancel',
+            text: 'Some translation',
+          },
+        ],
+      );
+      expect(onGranted).toHaveBeenCalledTimes(0);
+      expect(onDismiss).toHaveBeenCalledTimes(0);
+    });
+
+    it('triggers onDismiss if permissions are denied and user dismiss', async () => {
+      mockAlert.mockImplementationOnce((header, text, config) => {
+        // Run the dimiss action
+        config[0].onPress();
+      });
+
+      const {result} = renderHook(() => useCheckPermissions());
+
+      mockHasCameraPermissions.mockReturnValue(false);
+      mockHasMicrophonePermissions.mockReturnValue(false);
+
+      const onGranted = jest.fn();
+      const onDismiss = jest.fn();
+      await result.current.checkJoinPermissions(onGranted, onDismiss);
+
+      expect(onGranted).toHaveBeenCalledTimes(0);
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('triggers onGranted if onDismiss is undefined, permissions are denied and user dismiss', async () => {
+      mockAlert.mockImplementationOnce((header, text, config) => {
+        // Run the dimiss action
+        config[0].onPress();
+      });
+
+      const {result} = renderHook(() => useCheckPermissions());
+
+      mockHasCameraPermissions.mockReturnValue(false);
+      mockHasMicrophonePermissions.mockReturnValue(false);
+
+      const onGranted = jest.fn();
+      await result.current.checkJoinPermissions(onGranted);
+
+      expect(onGranted).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens settings and restarts app if permissions are denied and user confirms', async () => {
+      mockAlert.mockImplementationOnce((header, text, config) => {
+        // Run the confirm action
+        config[1].onPress();
+      });
+
+      const {result} = renderHook(() => useCheckPermissions());
+
+      mockHasCameraPermissions.mockReturnValue(false);
+      mockHasMicrophonePermissions.mockReturnValue(false);
+
+      const onGranted = jest.fn();
+      const onDismiss = jest.fn();
+      await result.current.checkJoinPermissions(onGranted, onDismiss);
+
+      expect(mockOpenSettings).toHaveBeenCalledTimes(1);
+      expect(mockRestartApp).toHaveBeenCalledTimes(1);
+      expect(onGranted).toHaveBeenCalledTimes(0);
+      expect(onDismiss).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/client/src/routes/Session/hooks/useCheckPermissions.ts
+++ b/client/src/routes/Session/hooks/useCheckPermissions.ts
@@ -19,6 +19,7 @@ const useCheckPermissions = () => {
 
   const openSettings = useCallback(async () => {
     await Linking.openSettings();
+    // Restart JS-bundle to let permissions come into effect - on Android, iOS already does this.
     restartApp();
   }, [restartApp]);
 

--- a/client/src/routes/Session/hooks/useCheckPermissions.ts
+++ b/client/src/routes/Session/hooks/useCheckPermissions.ts
@@ -1,0 +1,82 @@
+import {useCallback, useContext} from 'react';
+import {Alert, Linking} from 'react-native';
+import {useTranslation} from 'react-i18next';
+import useRestartApp from '../../../lib/codePush/hooks/useRestartApp';
+import {DailyContext} from '../../../lib/daily/DailyProvider';
+
+type Confirm = (
+  keyPrefix: 'join' | 'camera' | 'microphone',
+  onDismiss?: () => void,
+) => void;
+
+type CheckPermissions = (onGranted: () => void, onDismiss?: () => void) => void;
+
+const useCheckPermissions = () => {
+  const {t} = useTranslation('Component.CheckPermissions');
+  const restartApp = useRestartApp();
+  const {hasCameraPermissions, hasMicrophonePermissions} =
+    useContext(DailyContext);
+
+  const openSettings = useCallback(async () => {
+    await Linking.openSettings();
+    restartApp();
+  }, [restartApp]);
+
+  const confirm = useCallback<Confirm>(
+    (keyPrefix, onDismiss = () => {}) => {
+      Alert.alert(t(`${keyPrefix}.title`), t(`${keyPrefix}.message`), [
+        {
+          text: t(`${keyPrefix}.dismiss`),
+          onPress: onDismiss,
+        },
+        {
+          style: 'cancel',
+          text: t(`${keyPrefix}.confirm`),
+          onPress: openSettings,
+        },
+      ]);
+    },
+    [t, openSettings],
+  );
+
+  const checkJoinPermissions = useCallback<CheckPermissions>(
+    (onGranted, onDismiss) => {
+      if (hasCameraPermissions() && hasMicrophonePermissions()) {
+        onGranted();
+      } else {
+        confirm('join', onDismiss ?? onGranted);
+      }
+    },
+    [hasCameraPermissions, hasMicrophonePermissions, confirm],
+  );
+
+  const checkCameraPermissions = useCallback<CheckPermissions>(
+    (onGranted, onDismiss = () => {}) => {
+      if (hasCameraPermissions()) {
+        onGranted();
+      } else {
+        confirm('camera', onDismiss);
+      }
+    },
+    [hasCameraPermissions, confirm],
+  );
+
+  const checkMicrophonePermissions = useCallback<CheckPermissions>(
+    (onGranted, onDismiss = () => {}) => {
+      if (hasMicrophonePermissions()) {
+        onGranted();
+      } else {
+        confirm('camera', onDismiss);
+      }
+    },
+    [hasMicrophonePermissions, confirm],
+  );
+
+  return {
+    checkJoinPermissions,
+    checkCameraPermissions,
+    checkMicrophonePermissions,
+  };
+};
+
+export default useCheckPermissions;

--- a/content/src/ui/Component.CheckPermissions.json
+++ b/content/src/ui/Component.CheckPermissions.json
@@ -1,0 +1,39 @@
+{
+  "en": {
+    "join": {
+      "title": "Before you join",
+      "message": "You haven't given the app permissions to use camera and/or microphone. That's ok, but you won't be able to participate fully in the session.",
+      "dismiss": "Join anyway",
+      "confirm": "Open settings"
+    },
+    "camera": {
+      "title": "Permission for camera was denied",
+      "message": "Allow 29k sessions to access your camera so that you can participate in the session. This will restart the 29k session app.",
+      "dismiss": "Cancel",
+      "confirm": "Open Settings"
+    },
+    "microphone": {
+      "title": "Permission for microphone was denied",
+      "message": "Allow 29k sessions to access your microphone so that you can participate in the session. This will restart the 29k session app.",
+      "dismiss": "Cancel",
+      "confirm": "Open Settings"
+    }
+  },
+  "sv": {
+    "join": {
+      "title": "Innan du går med",
+      "message": "Du har inte gett appen tillåtelse att använda kameran och mikrofonen. Det är helt upp till dig. Vi vill bara att du ska veta att du då inte kan delta fullt ut i sessionen.",
+      "join": "Gå med ändå",
+      "openSettings": "Ändra inställningar"
+    }
+  },
+  "pt": {
+    "join": {
+      "title": "Antes de entrares",
+      "message": "Não deste permissões à app para poderes ligar/desligar a câmara e/ou o microfone. Não há problema mas desta forma não vais poder aproveitar ao máximo a sessão.",
+      "join": "Participar mesmo assim",
+      "openSettings": "Abrir configurações"
+    }
+  },
+  "es": {}
+}

--- a/content/src/ui/Screen.ChangingRoom.json
+++ b/content/src/ui/Screen.ChangingRoom.json
@@ -2,53 +2,17 @@
   "en": {
     "placeholder": "Please type your name",
     "join_button": "Join",
-    "cameraOff": "Camera is off",
-    "permissionsAlert": {
-      "join": {
-        "title": "Before you join",
-        "message": "You haven’t given the app permissions to use camera and/or microphone.That’s ok, but you won’t be able to participate fully in the session.",
-        "dismiss": "Join anyway",
-        "confirm": "Open settings"
-      },
-      "camera": {
-        "title": "Permission for camera was denied",
-        "message": "Allow 29k sessions to access your camera so that you can participate in the session. This will restart the 29k session app. ",
-        "dismiss": "Cancel",
-        "confirm": "Open Settings"
-      },
-      "microphone": {
-        "title": "Permission for microphone was denied",
-        "message": "Allow 29k sessions to access your microphone so that you can participate in the session. This will restart the 29k session app. ",
-        "dismiss": "Cancel",
-        "confirm": "Open Settings"
-      }
-    }
+    "cameraOff": "Camera is off"
   },
   "pt": {
     "placeholder": "Por favor escreve o teu nome",
     "join_button": "Participar",
-    "cameraOff": "A câmara está desligada",
-    "permissionsAlert": {
-      "join": {
-        "title": "Antes de entrares",
-        "message": "Não deste permissões à app para poderes ligar/desligar a câmara e/ou o microfone. Não há problema mas desta forma não vais poder aproveitar ao máximo a sessão.",
-        "join": "Participar mesmo assim",
-        "openSettings": "Abrir configurações"
-      }
-    }
+    "cameraOff": "A câmara está desligada"
   },
   "sv": {
     "placeholder": "Skriv ditt namn",
     "join_button": "Gå med",
-    "cameraOff": "Kameran är av",
-    "permissionsAlert": {
-      "join": {
-        "title": "Innan du går med",
-        "message": "Du har inte gett appen tillåtelse att använda kameran och mikrofonen. Det är helt upp till dig. Vi vill bara att du ska veta att du då inte kan delta fullt ut i sessionen.",
-        "join": "Gå med ändå",
-        "openSettings": "Ändra inställningar"
-      }
-    }
+    "cameraOff": "Kameran är av"
   },
   "es": {}
 }

--- a/content/src/ui/Screen.Session.json
+++ b/content/src/ui/Screen.Session.json
@@ -12,20 +12,6 @@
       "left": "{{name}} left",
       "networkQuality": "Unrealiable network connection",
       "muted": "You are muted"
-    },
-    "permissionsAlert": {
-      "camera": {
-        "title": "Permission for camera was denied",
-        "message": "Allow 29k sessions to access your camera so that you can participate in the session. This will restart the 29k session app. ",
-        "dismiss": "Cancel",
-        "confirm": "Open Settings"
-      },
-      "microphone": {
-        "title": "Permission for microphone was denied",
-        "message": "Allow 29k sessions to access your microphone so that you can participate in the session. This will restart the 29k session app. ",
-        "dismiss": "Cancel",
-        "confirm": "Open Settings"
-      }
     }
   },
   "pt": {


### PR DESCRIPTION
- [x] Re-use hook in `ChangingRoom` and `Session`
- [x] Restart JS-bundle after opening settings to re-evaluate permissions - haven't found a better solution on Android, iOS does this by default
- [x] Tests