### PR TITLE
Support custom social media meta for exercises

### DIFF
--- a/cms/src/fields/exercise.ts
+++ b/cms/src/fields/exercise.ts
@@ -34,7 +34,7 @@ export const SOCIAL_MEDIA: CmsField = {
     {
       label: '🪧 Title',
       name: 'title',
-      hint: 'Defaults to [📱 UI → DeepLink.JoinSessionInvite → title](#/collections/ui/entries/DeepLink.JoinSessionInvite)',
+      hint: `Defaults to ${NAME_FIELD.label}`,
       widget: 'string',
       i18n: true,
       required: false,
@@ -42,7 +42,6 @@ export const SOCIAL_MEDIA: CmsField = {
     {
       label: '📃 Description',
       name: 'description',
-      hint: 'Defaults to [📱 UI → DeepLink.JoinSessionInvite → description](#/collections/ui/entries/DeepLink.JoinSessionInvite)',
       widget: 'string',
       i18n: true,
       required: false,

--- a/cms/src/fields/exercise.ts
+++ b/cms/src/fields/exercise.ts
@@ -12,6 +12,7 @@ import {
   VIDEO_FIELD,
   DURATION_FIELD,
   HIDDEN_FIELD,
+  IMAGE_FIELD,
 } from './common';
 import {
   CONTENT_SLIDE,
@@ -20,6 +21,44 @@ import {
   REFLECTION_SLIDE,
   SHARING_SLIDE,
 } from './slides';
+import {CLOUDINARY_IMAGE_CONFIG} from './constants';
+
+export const SOCIAL_MEDIA: CmsField = {
+  label: '🔗 Social Media Meta Tags',
+  name: 'socialMeta',
+  widget: 'object',
+  collapsed: true,
+  required: false,
+  i18n: true,
+  fields: [
+    {
+      label: '🪧 Title',
+      name: 'title',
+      hint: 'Defaults to [📱 UI → DeepLink.JoinSessionInvite → title](#/collections/ui/entries/DeepLink.JoinSessionInvite)',
+      widget: 'string',
+      i18n: true,
+      required: false,
+    },
+    {
+      label: '📃 Description',
+      name: 'description',
+      hint: 'Defaults to [📱 UI → DeepLink.JoinSessionInvite → description](#/collections/ui/entries/DeepLink.JoinSessionInvite)',
+      widget: 'string',
+      i18n: true,
+      required: false,
+    },
+    {
+      label: '🌅 Image',
+      name: 'image',
+      hint: `Defaults to ${CARD_FIELD.label} → ${IMAGE_FIELD.label}`,
+      widget: 'image',
+      required: false,
+      i18n: true,
+      allow_multiple: false,
+      media_library: CLOUDINARY_IMAGE_CONFIG,
+    },
+  ],
+};
 
 export const INTRO_PORTAL: CmsField = {
   label: '🌇 Intro Portal',
@@ -93,6 +132,7 @@ const EXERCISE_FIELDS: Array<CmsField> = applyDefaults(
     DURATION_FIELD,
     PUBLISHED_FIELD,
     HIDDEN_FIELD,
+    SOCIAL_MEDIA,
     CARD_FIELD,
     THEME,
     INTRO_PORTAL,

--- a/content/src/ui/DeepLink.JoinSessionInvite.json
+++ b/content/src/ui/DeepLink.JoinSessionInvite.json
@@ -1,15 +1,15 @@
 {
   "en": {
-    "title": "29k session {{name}}",
-    "description": "With {{host}}"
+    "title": "29k session {{title}}",
+    "description": "With {{host}} - {{description}}"
   },
   "pt": {
-    "title": "Sessão 29k FJN: {{name}}",
-    "description": "Com {{host}}"
+    "title": "Sessão 29k FJN: {{title}}",
+    "description": "Com {{host}} - {{description}}"
   },
   "sv": {
-    "title": "29k-session: {{name}}",
-    "description": "Med {{host}}"
+    "title": "29k-session: {{title}}",
+    "description": "Med {{host}} - {{description}}"
   },
   "es": {}
 }

--- a/functions/src/models/dynamicLinks.spec.ts
+++ b/functions/src/models/dynamicLinks.spec.ts
@@ -32,7 +32,7 @@ jest.mock('../../../content/content.json', () => ({
         },
       },
       'DeepLink.JoinSessionInvite': {
-        title: 'Some link title: {{name}}',
+        title: 'Some link title: {{title}}',
         description: 'Some link description: {{host}}',
       },
     },
@@ -49,7 +49,7 @@ jest.mock('../../../content/content.json', () => ({
         },
       },
       'DeepLink.JoinSessionInvite': {
-        title: 'En länktitel: {{name}}',
+        title: 'En länktitel: {{title}}',
         description: 'En länkbeskrivning: {{host}}',
       },
     },
@@ -234,9 +234,9 @@ describe('createSessionInviteLink', () => {
           link: 'http://some.deep/link/base/joinSessionInvite/123456',
           navigationInfo: {enableForcedRedirect: false},
           socialMetaTagInfo: {
-            socialDescription: 'Some custom social meta description',
+            socialDescription: 'Some link description: Some Host Name',
             socialImageLink: 'http://some.custom.social.meta/image',
-            socialTitle: 'Some custom social meta title',
+            socialTitle: 'Some link title: Some custom social meta title',
           },
         },
       },

--- a/functions/src/models/dynamicLinks.spec.ts
+++ b/functions/src/models/dynamicLinks.spec.ts
@@ -21,6 +21,15 @@ jest.mock('../../../content/content.json', () => ({
             },
           },
         },
+        'some-socialMeta-exercise-id': {
+          published: true,
+          name: 'Some Other Exercise',
+          socialMeta: {
+            title: 'Some custom social meta title',
+            description: 'Some custom social meta description',
+            image: 'http://some.custom.social.meta/image',
+          },
+        },
       },
       'DeepLink.JoinSessionInvite': {
         title: 'Some link title: {{name}}',
@@ -185,6 +194,49 @@ describe('createSessionInviteLink', () => {
             socialDescription: 'Some link description: Some Host Name',
             socialImageLink: 'http://some.image/source.en',
             socialTitle: 'Some link title: Some Exercise',
+          },
+        },
+      },
+    });
+
+    expect(shortLink).toBe('https://some.short/session/link');
+  });
+
+  it('supports custom social meta override', async () => {
+    mockCreate.mockResolvedValueOnce({
+      data: {
+        shortLink: 'https://some.short/session/link',
+      },
+    });
+
+    const shortLink = await createSessionInviteLink(
+      123456,
+      'some-socialMeta-exercise-id',
+      'Some Host Name',
+      'en',
+    );
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockCreate).toHaveBeenCalledWith({
+      key: 'some-deep-link-api-key',
+      requestBody: {
+        dynamicLinkInfo: {
+          androidInfo: {
+            androidFallbackLink: 'http://some.android/fallback/link',
+            androidPackageName: 'some-deep-link-android-package-name',
+          },
+          domainUriPrefix: 'some-deep-link-domain-uri-prefix',
+          iosInfo: {
+            iosAppStoreId: 'some-deep-link-ios-appstore-id',
+            iosBundleId: 'some-deep-link-ios-bundle-id',
+            iosFallbackLink: 'http://some.ios/fallback/link',
+          },
+          link: 'http://some.deep/link/base/joinSessionInvite/123456',
+          navigationInfo: {enableForcedRedirect: false},
+          socialMetaTagInfo: {
+            socialDescription: 'Some custom social meta description',
+            socialImageLink: 'http://some.custom.social.meta/image',
+            socialTitle: 'Some custom social meta title',
           },
         },
       },

--- a/functions/src/models/dynamicLinks.ts
+++ b/functions/src/models/dynamicLinks.ts
@@ -64,7 +64,7 @@ export const createSessionInviteLink = async (
   language: LANGUAGE_TAG,
 ) => {
   // @ts-expect-error variable/string litteral as key is not yet supported https://www.i18next.com/overview/typescript#type-error-template-literal
-  const {name, card} = i18next.t(contentId, {
+  const {name, card, socialMeta} = i18next.t(contentId, {
     lng: language,
     ns: 'exercises',
     returnObjects: true,
@@ -72,9 +72,13 @@ export const createSessionInviteLink = async (
 
   const t = i18next.getFixedT(language, 'DeepLink.JoinSessionInvite');
 
-  const socialImageLink = card?.image?.source;
-  const socialTitle = t('title', {name});
-  const socialDescription = t('description', {host});
+  const socialImageLink = socialMeta?.image ?? card?.image?.source;
+  const socialTitle = socialMeta?.title ?? t('title', {name});
+  const socialDescription =
+    socialMeta?.description ??
+    t('description', {
+      host,
+    });
 
   return createDynamicLink(`joinSessionInvite/${inviteCode}`, {
     socialImageLink,

--- a/functions/src/models/dynamicLinks.ts
+++ b/functions/src/models/dynamicLinks.ts
@@ -73,12 +73,11 @@ export const createSessionInviteLink = async (
   const t = i18next.getFixedT(language, 'DeepLink.JoinSessionInvite');
 
   const socialImageLink = socialMeta?.image ?? card?.image?.source;
-  const socialTitle = socialMeta?.title ?? t('title', {name});
-  const socialDescription =
-    socialMeta?.description ??
-    t('description', {
-      host,
-    });
+  const socialTitle = t('title', {title: socialMeta?.title ?? name});
+  const socialDescription = t('description', {
+    host,
+    description: socialMeta?.description,
+  });
 
   return createDynamicLink(`joinSessionInvite/${inviteCode}`, {
     socialImageLink,

--- a/shared/src/types/generated/Exercise.ts
+++ b/shared/src/types/generated/Exercise.ts
@@ -1,6 +1,12 @@
 /* eslint-disable */
 /* tslint:disable */
 
+export interface ExerciseSocialMediaMetaTags {
+  title?: string;
+  description?: string;
+  image?: string;
+}
+
 export interface ExerciseCardImage {
   description?: string;
   source?: string;
@@ -189,6 +195,7 @@ export interface Exercise {
   duration: number;
   published: boolean;
   hidden?: boolean;
+  socialMeta?: ExerciseSocialMediaMetaTags;
   card: ExerciseCard;
   theme?: ExerciseTheme;
   introPortal?: ExerciseIntroPortal;


### PR DESCRIPTION
Adds new fields to the CMS for custom social media tagging / link descriptions for exercises
| New Exercise CMS fields | Deep link preview |
|-|-|
| <img width="809" alt="image" src="https://user-images.githubusercontent.com/474066/209921749-931a4409-51e0-4dff-8a41-6097f6102751.png"> | <img width="404" alt="image" src="https://user-images.githubusercontent.com/474066/209921692-bbd99359-4de5-4028-b238-43a81dc5242b.png"> |
