### PR TITLE
Add description to cms and session modal

### DIFF
--- a/client/src/lib/navigation/ModalStack.tsx
+++ b/client/src/lib/navigation/ModalStack.tsx
@@ -121,7 +121,11 @@ const ModalStack = () => {
       <Screen name="OverlayStack" component={OverlayStack} />
 
       <Group screenOptions={sheetModalScreenOptions}>
-        <Screen name={'SessionModal'} component={SessionModal} />
+        <Screen
+          name={'SessionModal'}
+          component={SessionModal}
+          options={tallSheetModalScreenOptions}
+        />
         <Screen name={'CreateSessionModal'} component={CreateSessionModal} />
         <Screen
           name={'UpgradeAccountModal'}

--- a/client/src/routes/SessionModal/SessionModal.tsx
+++ b/client/src/routes/SessionModal/SessionModal.tsx
@@ -50,6 +50,7 @@ import Interested from '../../lib/components/Interested/Interested';
 import RadioButton from '../../lib/components/Buttons/RadioButton/RadioButton';
 import usePinnedSessons from '../../lib/sessions/hooks/usePinnedSessions';
 import useLogSessionMetricEvents from '../../lib/sessions/hooks/useLogSessionMetricEvents';
+import Markdown from '../../lib/components/Typography/Markdown/Markdown';
 
 const TypeWrapper = styled(TouchableOpacity)({
   justifyContent: 'center',
@@ -317,7 +318,15 @@ const SessionModal = () => {
           />
         </SpaceBetweenRow>
       </Content>
-      <Spacer8 />
+      {exercise?.description && (
+        <>
+          <Spacer16 />
+          <Gutters>
+            <Markdown>{exercise?.description}</Markdown>
+          </Gutters>
+        </>
+      )}
+      <Spacer16 />
       {!editMode && (
         <>
           <Gutters>

--- a/cms/src/fields/common.ts
+++ b/cms/src/fields/common.ts
@@ -42,6 +42,14 @@ export const NAME_FIELD: CmsField = {
   widget: 'string',
 };
 
+export const DESCRIPTION_FIELD: CmsField = {
+  label: '📃 Description',
+  name: 'description',
+  widget: 'markdown',
+  required: false,
+  i18n: true,
+};
+
 export const DURATION_FIELD: CmsField = {
   label: '⏱ Duration',
   name: 'duration',

--- a/cms/src/fields/exercise.ts
+++ b/cms/src/fields/exercise.ts
@@ -13,6 +13,7 @@ import {
   DURATION_FIELD,
   HIDDEN_FIELD,
   IMAGE_FIELD,
+  DESCRIPTION_FIELD,
 } from './common';
 import {
   CONTENT_SLIDE,
@@ -128,6 +129,7 @@ const EXERCISE_FIELDS: Array<CmsField> = applyDefaults(
   [
     ID_FIELD,
     NAME_FIELD,
+    DESCRIPTION_FIELD,
     DURATION_FIELD,
     PUBLISHED_FIELD,
     HIDDEN_FIELD,

--- a/shared/src/types/generated/Exercise.ts
+++ b/shared/src/types/generated/Exercise.ts
@@ -192,6 +192,7 @@ export interface ExerciseSlideHostSlide {
 export interface Exercise {
   id: any;
   name: string;
+  description?: string;
   duration: number;
   published: boolean;
   hidden?: boolean;


### PR DESCRIPTION
Adds description to session modal and opens it with `tallSheetModalScreenOptions` to show all contents of the modal
<image src="https://user-images.githubusercontent.com/1139207/211349059-2ec0fb2a-c67d-4869-9206-a7bd2116c6de.png" width="200" />
