### PR TITLE
Validate user for private sessions

### DIFF
--- a/content/src/ui/Screen.ChangingRoom.json
+++ b/content/src/ui/Screen.ChangingRoom.json
@@ -2,17 +2,32 @@
   "en": {
     "placeholder": "Please type your name",
     "join_button": "Join",
-    "cameraOff": "Camera is off"
+    "cameraOff": "Camera is off",
+    "errorTitle": "Could not join session.",
+    "errors": {
+      "validateSession/not-found": "Could not find session.",
+      "validateSession/user-not-found": "User not found for session."
+    }
   },
   "pt": {
     "placeholder": "Por favor escreve o teu nome",
     "join_button": "Participar",
-    "cameraOff": "A câmara está desligada"
+    "cameraOff": "A câmara está desligada",
+    "errorTitle": "Could not join session.",
+    "errors": {
+      "validateSession/not-found": "Could not find session.",
+      "validateSession/user-not-found": "User not part of session."
+    }
   },
   "sv": {
     "placeholder": "Skriv ditt namn",
     "join_button": "Gå med",
-    "cameraOff": "Kameran är av"
+    "cameraOff": "Kameran är av",
+    "errorTitle": "Gick inte att gå med i sessionen.",
+    "errors": {
+      "validateSession/not-found": "Kunde inte hitta sessionen.",
+      "validateSession/user-not-found": "Användaren hittades inte för sessionen."
+    }
   },
   "es": {}
 }

--- a/functions/src/controllers/__mocks__/sessions.ts
+++ b/functions/src/controllers/__mocks__/sessions.ts
@@ -4,3 +4,4 @@ export const removeSession = jest.fn();
 export const updateSession = jest.fn();
 export const updateExerciseState = jest.fn();
 export const joinSession = jest.fn();
+export const getSessionToken = jest.fn();

--- a/functions/src/controllers/errors/RequestError.ts
+++ b/functions/src/controllers/errors/RequestError.ts
@@ -1,11 +1,16 @@
 import {VerificationError} from '../../../../shared/src/errors/User';
-import {JoinSessionError} from '../../../../shared/src/errors/Session';
+import {
+  JoinSessionError,
+  ValidateSessionError,
+} from '../../../../shared/src/errors/Session';
 
 export class RequestError extends Error {
-  constructor(code: VerificationError | JoinSessionError) {
+  constructor(
+    code: VerificationError | JoinSessionError | ValidateSessionError,
+  ) {
     super(code);
     this.code = code;
   }
 
-  code: VerificationError | JoinSessionError;
+  code: VerificationError | JoinSessionError | ValidateSessionError;
 }

--- a/functions/src/lib/__mocks__/dailyUtils.ts
+++ b/functions/src/lib/__mocks__/dailyUtils.ts
@@ -1,0 +1,1 @@
+export const generateSessionToken = jest.fn();

--- a/shared/src/errors/Session.ts
+++ b/shared/src/errors/Session.ts
@@ -1,3 +1,9 @@
+export enum ValidateSessionError {
+  notFound = 'validateSession/not-found',
+  userNotFound = 'validateSession/user-not-found',
+  userNotAuthorized = 'validateSession/user-not-authorized',
+}
+
 export enum JoinSessionError {
   notAvailable = 'joinSession/not-available',
   notFound = 'joinSession/not-found',


### PR DESCRIPTION
Validate that a user is part of a private session when requesting a token. Handle errors in the client for when user is not part or session is not found. None of witch should happen from regular usage.

This should be safe to merge into main and not need to wait for a release, will only affect clients that requests tokens
