### PR TITLE
Recreate auth on invalid-refresh

### DIFF
--- a/client/src/lib/apiClient/apiClient.ts
+++ b/client/src/lib/apiClient/apiClient.ts
@@ -39,7 +39,8 @@ const getAuthorizationToken = async (): Promise<string> => {
         if (
           firebaseError.code === 'auth/internal-error' ||
           firebaseError.code === 'auth/id-token-expired' ||
-          firebaseError.code === 'auth/id-token-revoked'
+          firebaseError.code === 'auth/id-token-revoked' ||
+          firebaseError.code === 'auth/invalid-refresh'
         ) {
           await recreateUser();
           return await getAuthorizationToken();


### PR DESCRIPTION
Issue: https://29k.slack.com/archives/C7DTMLM6Y/p1673448241344749

### Description of the Change

Seems like both Jakob and I got this error in our client console when our app was with outdated auth data.
`NativeFirebaseError: [auth/invalid-refresh] An internal error has occurred. [ INVALID_REFRESH_TOKEN ]`

This got fixed on our devices by us cleaning up the app data on our emulator/phone.

With this change the app would re-create the auth data automatically.
