### PR TITLE
Enable backup of async storage

### DIFF
--- a/client/android/app/src/main/AndroidManifest.xml
+++ b/client/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
-      android:allowBackup="false"
+      android:allowBackup="true"
       android:theme="@style/AppTheme"
       android:hardwareAccelerated="true">
       <service android:name="com.daily.reactlibrary.DailyOngoingMeetingForegroundService"/>

--- a/client/ios/Supporting/Info.plist
+++ b/client/ios/Supporting/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>RCTAsyncStorageExcludeFromBackup</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
[Task in notion](https://www.notion.so/29k/Early-Access-2794500652b34c64b0aff0dbbc53e0ab#66ffe99758ac4eaf969f057341063c38)

This will persist the stuff we put in async storage across devices
* https://react-native-async-storage.github.io/async-storage/docs/advanced/backup
* https://developer.android.com/guide/topics/manifest/application-element#allowbackup