### PR TITLE
Completed sessions

### DIFF
--- a/client/src/lib/sessions/hooks/usePinnedSessions.spec.ts
+++ b/client/src/lib/sessions/hooks/usePinnedSessions.spec.ts
@@ -28,6 +28,7 @@ describe('usePinnedSessions', () => {
             pinnedSessions: [
               {id: 'session-id-1', expires: new Date('2022-12-20')},
             ],
+            completedSessions: [],
           },
         },
       });
@@ -47,6 +48,7 @@ describe('usePinnedSessions', () => {
             pinnedSessions: [
               {id: 'session-id-1', expires: new Date('2022-12-20')},
             ],
+            completedSessions: [],
           },
         },
       });
@@ -90,6 +92,7 @@ describe('usePinnedSessions', () => {
               pinnedSessions: [
                 {id: 'session-id-1', expires: new Date('2022-12-20')},
               ],
+              completedSessions: [],
             },
           },
         });
@@ -117,6 +120,7 @@ describe('usePinnedSessions', () => {
               pinnedSessions: [
                 {id: 'session-id-1', expires: new Date('2022-11-09')},
               ],
+              completedSessions: [],
             },
           },
         });
@@ -141,6 +145,7 @@ describe('usePinnedSessions', () => {
                 {id: 'session-id-1', expires: new Date('2022-11-09')},
                 {id: 'session-id-2', expires: new Date('2022-12-20')},
               ],
+              completedSessions: [],
             },
           },
         });

--- a/client/src/lib/sessions/hooks/useSessions.spec.ts
+++ b/client/src/lib/sessions/hooks/useSessions.spec.ts
@@ -236,13 +236,7 @@ describe('useSessions', () => {
       });
       useUserState.setState({
         user: {uid: 'user-id'} as FirebaseAuthTypes.User,
-        userState: {
-          'user-id': {
-            pinnedSessions: [
-              {id: 'session-id-1', expires: new Date('2022-12-20')},
-            ],
-          },
-        },
+        userState: {},
       });
 
       const {result} = renderHook(() => useSessions());

--- a/client/src/lib/sessions/hooks/useSessions.spec.ts
+++ b/client/src/lib/sessions/hooks/useSessions.spec.ts
@@ -163,6 +163,7 @@ describe('useSessions', () => {
             pinnedSessions: [
               {id: 'session-id-1', expires: new Date('2022-12-20')},
             ],
+            completedSessions: [],
           },
         },
       });
@@ -212,6 +213,7 @@ describe('useSessions', () => {
             pinnedSessions: [
               {id: 'session-id-1', expires: new Date('2022-12-20')},
             ],
+            completedSessions: [],
           },
         },
       });

--- a/client/src/lib/user/hooks/useCurrentUserState.spec.ts
+++ b/client/src/lib/user/hooks/useCurrentUserState.spec.ts
@@ -10,7 +10,9 @@ describe('useCurrentUserState', () => {
       userState: {
         'user-id': {
           pinnedSessions: [{id: 'session-id', expires: new Date()}],
-          completedSessions: [{id: 'other-session-id'}],
+          completedSessions: [
+            {id: 'other-session-id', completedAt: new Date()},
+          ],
         },
       },
     });
@@ -19,7 +21,9 @@ describe('useCurrentUserState', () => {
 
     expect(result.current).toEqual({
       pinnedSessions: [{id: 'session-id', expires: expect.any(Date)}],
-      completedSessions: [{id: 'other-session-id'}],
+      completedSessions: [
+        {id: 'other-session-id', completedAt: expect.any(Date)},
+      ],
     });
   });
 });

--- a/client/src/lib/user/hooks/useCurrentUserState.spec.ts
+++ b/client/src/lib/user/hooks/useCurrentUserState.spec.ts
@@ -8,7 +8,10 @@ describe('useCurrentUserState', () => {
     useUserState.setState({
       user: {uid: 'user-id'} as FirebaseAuthTypes.User,
       userState: {
-        'user-id': {pinnedSessions: [{id: 'session-id', expires: new Date()}]},
+        'user-id': {
+          pinnedSessions: [{id: 'session-id', expires: new Date()}],
+          completedSessions: [{id: 'other-session-id'}],
+        },
       },
     });
 
@@ -16,6 +19,7 @@ describe('useCurrentUserState', () => {
 
     expect(result.current).toEqual({
       pinnedSessions: [{id: 'session-id', expires: expect.any(Date)}],
+      completedSessions: [{id: 'other-session-id'}],
     });
   });
 });

--- a/client/src/lib/user/state/state.spec.ts
+++ b/client/src/lib/user/state/state.spec.ts
@@ -28,6 +28,7 @@ describe('user - state', () => {
         userState: {
           'user-id': {
             pinnedSessions: [{id: 'other-session-id', expires: new Date()}],
+            completedSessions: [{id: 'other-session-id'}],
           },
         },
       });
@@ -51,6 +52,7 @@ describe('user - state', () => {
         userState: {
           'user-id-2': {
             pinnedSessions: [{id: 'other-session-id', expires: new Date()}],
+            completedSessions: [{id: 'other-session-id'}],
           },
         },
       });
@@ -72,6 +74,72 @@ describe('user - state', () => {
     });
   });
 
+  describe('setCompletedSessions', () => {
+    it('should set pinned sessions on empty userState', () => {
+      useUserState.setState({
+        user: {uid: 'user-id'} as FirebaseAuthTypes.User,
+        userState: {},
+      });
+
+      const {result} = renderHook(() => useUserState());
+
+      act(() => {
+        result.current.setCompletedSessions([{id: 'session-id'}]);
+      });
+
+      expect(result.current.userState['user-id'].completedSessions).toEqual([
+        {id: 'session-id'},
+      ]);
+    });
+
+    it('should replace completed session on existing userState', () => {
+      useUserState.setState({
+        user: {uid: 'user-id'} as FirebaseAuthTypes.User,
+        userState: {
+          'user-id': {
+            pinnedSessions: [],
+            completedSessions: [{id: 'session-id'}],
+          },
+        },
+      });
+
+      const {result} = renderHook(() => useUserState());
+
+      act(() => {
+        result.current.setCompletedSessions([{id: 'session-id'}]);
+      });
+
+      expect(result.current.userState['user-id'].completedSessions).toEqual([
+        {id: 'session-id'},
+      ]);
+    });
+
+    it('should keep other users state', () => {
+      useUserState.setState({
+        user: {uid: 'user-id'} as FirebaseAuthTypes.User,
+        userState: {
+          'user-id-2': {
+            pinnedSessions: [],
+            completedSessions: [{id: 'session-id'}],
+          },
+        },
+      });
+
+      const {result} = renderHook(() => useUserState());
+
+      act(() => {
+        result.current.setCompletedSessions([{id: 'session-id'}]);
+      });
+
+      expect(result.current.userState['user-id'].completedSessions).toEqual([
+        {id: 'session-id'},
+      ]);
+      expect(result.current.userState['user-id-2'].completedSessions).toEqual([
+        {id: 'session-id'},
+      ]);
+    });
+  });
+
   describe('reset', () => {
     it('should keep user state when not deleted', () => {
       useUserState.setState({
@@ -79,6 +147,7 @@ describe('user - state', () => {
         userState: {
           'user-id': {
             pinnedSessions: [{id: 'session-id', expires: new Date()}],
+            completedSessions: [{id: 'completed-session-id'}],
           },
         },
       });
@@ -100,9 +169,11 @@ describe('user - state', () => {
         userState: {
           'user-id': {
             pinnedSessions: [{id: 'session-id', expires: new Date()}],
+            completedSessions: [{id: 'completed-session-id'}],
           },
           'user-id-2': {
             pinnedSessions: [{id: 'session-id', expires: new Date()}],
+            completedSessions: [{id: 'completed-session-id'}],
           },
         },
       });

--- a/client/src/lib/user/state/state.spec.ts
+++ b/client/src/lib/user/state/state.spec.ts
@@ -74,8 +74,8 @@ describe('user - state', () => {
     });
   });
 
-  describe('setCompletedSessions', () => {
-    it('should set pinned sessions on empty userState', () => {
+  describe('addCompletedSession', () => {
+    it('should set completed sessions on empty userState', () => {
       useUserState.setState({
         user: {uid: 'user-id'} as FirebaseAuthTypes.User,
         userState: {},
@@ -84,7 +84,7 @@ describe('user - state', () => {
       const {result} = renderHook(() => useUserState());
 
       act(() => {
-        result.current.setCompletedSessions([{id: 'session-id'}]);
+        result.current.addCompletedSession({id: 'session-id'});
       });
 
       expect(result.current.userState['user-id'].completedSessions).toEqual([
@@ -92,7 +92,7 @@ describe('user - state', () => {
       ]);
     });
 
-    it('should replace completed session on existing userState', () => {
+    it('should add completed session on existing userState', () => {
       useUserState.setState({
         user: {uid: 'user-id'} as FirebaseAuthTypes.User,
         userState: {
@@ -106,11 +106,12 @@ describe('user - state', () => {
       const {result} = renderHook(() => useUserState());
 
       act(() => {
-        result.current.setCompletedSessions([{id: 'session-id'}]);
+        result.current.addCompletedSession({id: 'another-session-id'});
       });
 
       expect(result.current.userState['user-id'].completedSessions).toEqual([
         {id: 'session-id'},
+        {id: 'another-session-id'},
       ]);
     });
 
@@ -128,7 +129,7 @@ describe('user - state', () => {
       const {result} = renderHook(() => useUserState());
 
       act(() => {
-        result.current.setCompletedSessions([{id: 'session-id'}]);
+        result.current.addCompletedSession({id: 'session-id'});
       });
 
       expect(result.current.userState['user-id'].completedSessions).toEqual([

--- a/client/src/lib/user/state/state.spec.ts
+++ b/client/src/lib/user/state/state.spec.ts
@@ -28,7 +28,7 @@ describe('user - state', () => {
         userState: {
           'user-id': {
             pinnedSessions: [{id: 'other-session-id', expires: new Date()}],
-            completedSessions: [{id: 'other-session-id'}],
+            completedSessions: [],
           },
         },
       });
@@ -52,7 +52,7 @@ describe('user - state', () => {
         userState: {
           'user-id-2': {
             pinnedSessions: [{id: 'other-session-id', expires: new Date()}],
-            completedSessions: [{id: 'other-session-id'}],
+            completedSessions: [],
           },
         },
       });
@@ -84,11 +84,14 @@ describe('user - state', () => {
       const {result} = renderHook(() => useUserState());
 
       act(() => {
-        result.current.addCompletedSession({id: 'session-id'});
+        result.current.addCompletedSession({
+          id: 'session-id',
+          completedAt: new Date(),
+        });
       });
 
       expect(result.current.userState['user-id'].completedSessions).toEqual([
-        {id: 'session-id'},
+        {id: 'session-id', completedAt: expect.any(Date)},
       ]);
     });
 
@@ -98,7 +101,7 @@ describe('user - state', () => {
         userState: {
           'user-id': {
             pinnedSessions: [],
-            completedSessions: [{id: 'session-id'}],
+            completedSessions: [{id: 'session-id', completedAt: new Date()}],
           },
         },
       });
@@ -106,12 +109,15 @@ describe('user - state', () => {
       const {result} = renderHook(() => useUserState());
 
       act(() => {
-        result.current.addCompletedSession({id: 'another-session-id'});
+        result.current.addCompletedSession({
+          id: 'another-session-id',
+          completedAt: new Date(),
+        });
       });
 
       expect(result.current.userState['user-id'].completedSessions).toEqual([
-        {id: 'session-id'},
-        {id: 'another-session-id'},
+        {id: 'session-id', completedAt: expect.any(Date)},
+        {id: 'another-session-id', completedAt: expect.any(Date)},
       ]);
     });
 
@@ -121,7 +127,7 @@ describe('user - state', () => {
         userState: {
           'user-id-2': {
             pinnedSessions: [],
-            completedSessions: [{id: 'session-id'}],
+            completedSessions: [{id: 'session-id', completedAt: new Date()}],
           },
         },
       });
@@ -129,14 +135,17 @@ describe('user - state', () => {
       const {result} = renderHook(() => useUserState());
 
       act(() => {
-        result.current.addCompletedSession({id: 'session-id'});
+        result.current.addCompletedSession({
+          id: 'session-id',
+          completedAt: new Date(),
+        });
       });
 
       expect(result.current.userState['user-id'].completedSessions).toEqual([
-        {id: 'session-id'},
+        {id: 'session-id', completedAt: expect.any(Date)},
       ]);
       expect(result.current.userState['user-id-2'].completedSessions).toEqual([
-        {id: 'session-id'},
+        {id: 'session-id', completedAt: expect.any(Date)},
       ]);
     });
   });
@@ -147,8 +156,10 @@ describe('user - state', () => {
         user: {uid: 'user-id'} as FirebaseAuthTypes.User,
         userState: {
           'user-id': {
-            pinnedSessions: [{id: 'session-id', expires: new Date()}],
-            completedSessions: [{id: 'completed-session-id'}],
+            pinnedSessions: [{id: 'pinned-session-id', expires: new Date()}],
+            completedSessions: [
+              {id: 'completed-session-id', completedAt: new Date()},
+            ],
           },
         },
       });
@@ -160,7 +171,10 @@ describe('user - state', () => {
       });
 
       expect(result.current.userState['user-id'].pinnedSessions).toEqual([
-        {id: 'session-id', expires: expect.any(Date)},
+        {id: 'pinned-session-id', expires: expect.any(Date)},
+      ]);
+      expect(result.current.userState['user-id'].completedSessions).toEqual([
+        {id: 'completed-session-id', completedAt: expect.any(Date)},
       ]);
     });
 
@@ -169,12 +183,16 @@ describe('user - state', () => {
         user: {uid: 'user-id'} as FirebaseAuthTypes.User,
         userState: {
           'user-id': {
-            pinnedSessions: [{id: 'session-id', expires: new Date()}],
-            completedSessions: [{id: 'completed-session-id'}],
+            pinnedSessions: [{id: 'pinned-session-id', expires: new Date()}],
+            completedSessions: [
+              {id: 'completed-session-id', completedAt: new Date()},
+            ],
           },
           'user-id-2': {
-            pinnedSessions: [{id: 'session-id', expires: new Date()}],
-            completedSessions: [{id: 'completed-session-id'}],
+            pinnedSessions: [{id: 'pinned-session-id', expires: new Date()}],
+            completedSessions: [
+              {id: 'completed-session-id', completedAt: new Date()},
+            ],
           },
         },
       });
@@ -187,7 +205,10 @@ describe('user - state', () => {
 
       expect(result.current.userState['user-id']).toBe(undefined);
       expect(result.current.userState['user-id-2'].pinnedSessions).toEqual([
-        {id: 'session-id', expires: expect.any(Date)},
+        {id: 'pinned-session-id', expires: expect.any(Date)},
+      ]);
+      expect(result.current.userState['user-id-2'].completedSessions).toEqual([
+        {id: 'completed-session-id', completedAt: expect.any(Date)},
       ]);
     });
   });

--- a/client/src/lib/user/state/state.ts
+++ b/client/src/lib/user/state/state.ts
@@ -11,6 +11,7 @@ type PinnedSession = {
 
 type CompletedSession = {
   id: string;
+  completedAt: Date;
 };
 
 type UserState = {

--- a/client/src/lib/user/state/state.ts
+++ b/client/src/lib/user/state/state.ts
@@ -9,7 +9,14 @@ type PinnedSession = {
   expires: Date;
 };
 
-type UserState = {pinnedSessions: Array<PinnedSession>};
+type CompletedSession = {
+  id: string;
+};
+
+type UserState = {
+  pinnedSessions: Array<PinnedSession>;
+  completedSessions: Array<CompletedSession>;
+};
 
 type State = {
   user: FirebaseAuthTypes.User | null;
@@ -25,6 +32,7 @@ type Actions = {
     claims: State['claims'];
   }) => void;
   setPinnedSessions: (pinnedSessions: Array<PinnedSession>) => void;
+  setCompletedSessions: (completedSessions: Array<CompletedSession>) => void;
   reset: (isDelete?: boolean) => void;
 };
 
@@ -52,6 +60,19 @@ const useUserState = create<State & Actions>()(
             userState: lensSet(
               userStateLens(user.uid, 'pinnedSessions'),
               pinnedSessions,
+              userState,
+            ),
+          });
+        }
+      },
+      setCompletedSessions: completedSessions => {
+        const user = get().user;
+        const userState = get().userState;
+        if (user) {
+          set({
+            userState: lensSet(
+              userStateLens(user.uid, 'completedSessions'),
+              completedSessions,
               userState,
             ),
           });

--- a/client/src/lib/user/state/state.ts
+++ b/client/src/lib/user/state/state.ts
@@ -32,7 +32,7 @@ type Actions = {
     claims: State['claims'];
   }) => void;
   setPinnedSessions: (pinnedSessions: Array<PinnedSession>) => void;
-  setCompletedSessions: (completedSessions: Array<CompletedSession>) => void;
+  addCompletedSession: (completedSession: CompletedSession) => void;
   reset: (isDelete?: boolean) => void;
 };
 
@@ -65,14 +65,18 @@ const useUserState = create<State & Actions>()(
           });
         }
       },
-      setCompletedSessions: completedSessions => {
+      addCompletedSession: completedSession => {
         const user = get().user;
         const userState = get().userState;
+
         if (user) {
           set({
             userState: lensSet(
               userStateLens(user.uid, 'completedSessions'),
-              completedSessions,
+              [
+                ...(userState[user.uid]?.completedSessions || []),
+                completedSession,
+              ],
               userState,
             ),
           });

--- a/client/src/routes/Session/Session.tsx
+++ b/client/src/routes/Session/Session.tsx
@@ -141,7 +141,7 @@ const Session = () => {
     if (sessionState?.completed) {
       addCompletedSession({
         id: sessionState?.id,
-        completedAt: dayjs().toDate(),
+        completedAt: dayjs().utc().toDate(),
       });
       logSessionMetricEvent('Complete Sharing Session');
     }

--- a/client/src/routes/Session/Session.tsx
+++ b/client/src/routes/Session/Session.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useContext, useEffect} from 'react';
+import React, {useCallback, useContext, useEffect, useMemo} from 'react';
 import styled from 'styled-components/native';
 import {RouteProp, useNavigation, useRoute} from '@react-navigation/native';
 import {useTranslation} from 'react-i18next';
@@ -45,6 +45,7 @@ import useSessionExercise from './hooks/useSessionExercise';
 import useUpdateSessionState from './hooks/useUpdateSessionState';
 import useLogInSessionMetricEvents from './hooks/useLogInSessionMetricEvents';
 import useCheckPermissions from './hooks/useCheckPermissions';
+import useUserState from '../../lib/user/state/state';
 
 const Spotlight = styled.View({
   aspectRatio: '0.9375',
@@ -118,6 +119,13 @@ const Session = () => {
   const {checkCameraPermissions, checkMicrophonePermissions} =
     useCheckPermissions();
   const user = useUser();
+  const {setCompletedSessions} = useUserState();
+  const userState = useUserState(state => state.userState);
+
+  const completedSessions = useMemo(
+    () => userState?.completedSessions ?? [],
+    [userState],
+  );
 
   const hasAudio = Boolean(me?.audioTrack);
   const hasVideo = Boolean(me?.videoTrack);
@@ -132,6 +140,7 @@ const Session = () => {
 
   useEffect(() => {
     if (sessionState?.completed) {
+      setCompletedSessions([...completedSessions, {id: session.id}]);
       logSessionMetricEvent('Complete Sharing Session');
     }
   }, [sessionState?.completed, logSessionMetricEvent]);

--- a/client/src/routes/Session/Session.tsx
+++ b/client/src/routes/Session/Session.tsx
@@ -3,40 +3,21 @@ import styled from 'styled-components/native';
 import {RouteProp, useNavigation, useRoute} from '@react-navigation/native';
 import {useTranslation} from 'react-i18next';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import dayjs from 'dayjs';
 
-import useSessionState from './state/state';
-import {
-  BottomSafeArea,
-  Spacer12,
-  Spacer16,
-  Spacer32,
-  TopSafeArea,
-} from '../../lib/components/Spacers/Spacer';
+import {SPACINGS} from '../../lib/constants/spacings';
 import {COLORS} from '../../../../shared/src/constants/colors';
+
+import {DailyUserData} from '../../../../shared/src/types/Session';
 import {SessionStackProps} from '../../lib/navigation/constants/routes';
 import {DailyContext} from '../../lib/daily/DailyProvider';
-import ExerciseSlides from './components/ExerciseSlides/ExerciseSlides';
-import Participants from './components/Participants/Participants';
+
+import useSessionState from './state/state';
 import useSessionParticipants from './hooks/useSessionParticipants';
 import useSessionSlideState from './hooks/useSessionSlideState';
-import ProgressBar from './components/ProgressBar/ProgressBar';
-import {SPACINGS} from '../../lib/constants/spacings';
-import ContentControls from './components/ContentControls/ContentControls';
-import {DailyUserData} from '../../../../shared/src/types/Session';
-import IconButton from '../../lib/components/Buttons/IconButton/IconButton';
-import {
-  FilmCameraIcon,
-  FilmCameraOffIcon,
-  HangUpIcon,
-  MicrophoneIcon,
-  MicrophoneOffIcon,
-} from '../../lib/components/Icons';
 import usePreventGoingBack from '../../lib/navigation/hooks/usePreventGoingBack';
 import useLeaveSession from './hooks/useLeaveSession';
 import useIsSessionHost from './hooks/useIsSessionHost';
-import Button from '../../lib/components/Buttons/Button';
-import HostNotes from './components/HostNotes/HostNotes';
-import Screen from '../../lib/components/Screen/Screen';
 import useLocalParticipant from '../../lib/daily/hooks/useLocalParticipant';
 import useUser from '../../lib/user/hooks/useUser';
 import useSubscribeToSessionIfFocused from './hooks/useSusbscribeToSessionIfFocused';
@@ -46,6 +27,30 @@ import useUpdateSessionState from './hooks/useUpdateSessionState';
 import useLogInSessionMetricEvents from './hooks/useLogInSessionMetricEvents';
 import useCheckPermissions from './hooks/useCheckPermissions';
 import useUserState from '../../lib/user/state/state';
+
+import {
+  BottomSafeArea,
+  Spacer12,
+  Spacer16,
+  Spacer32,
+  TopSafeArea,
+} from '../../lib/components/Spacers/Spacer';
+
+import ExerciseSlides from './components/ExerciseSlides/ExerciseSlides';
+import Participants from './components/Participants/Participants';
+import ProgressBar from './components/ProgressBar/ProgressBar';
+import ContentControls from './components/ContentControls/ContentControls';
+import IconButton from '../../lib/components/Buttons/IconButton/IconButton';
+import {
+  FilmCameraIcon,
+  FilmCameraOffIcon,
+  HangUpIcon,
+  MicrophoneIcon,
+  MicrophoneOffIcon,
+} from '../../lib/components/Icons';
+import Button from '../../lib/components/Buttons/Button';
+import HostNotes from './components/HostNotes/HostNotes';
+import Screen from '../../lib/components/Screen/Screen';
 
 const Spotlight = styled.View({
   aspectRatio: '0.9375',
@@ -134,7 +139,10 @@ const Session = () => {
 
   useEffect(() => {
     if (sessionState?.completed) {
-      addCompletedSession({id: sessionState?.id});
+      addCompletedSession({
+        id: sessionState?.id,
+        completedAt: dayjs().toDate(),
+      });
       logSessionMetricEvent('Complete Sharing Session');
     }
   }, [

--- a/client/src/routes/Session/Session.tsx
+++ b/client/src/routes/Session/Session.tsx
@@ -141,7 +141,7 @@ const Session = () => {
     if (sessionState?.completed) {
       addCompletedSession({
         id: sessionState?.id,
-        completedAt: dayjs().utc().toDate(),
+        completedAt: dayjs.utc().toDate(),
       });
       logSessionMetricEvent('Complete Sharing Session');
     }

--- a/client/src/routes/Session/Session.tsx
+++ b/client/src/routes/Session/Session.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useContext, useEffect, useMemo} from 'react';
+import React, {useCallback, useContext, useEffect} from 'react';
 import styled from 'styled-components/native';
 import {RouteProp, useNavigation, useRoute} from '@react-navigation/native';
 import {useTranslation} from 'react-i18next';
@@ -119,13 +119,7 @@ const Session = () => {
   const {checkCameraPermissions, checkMicrophonePermissions} =
     useCheckPermissions();
   const user = useUser();
-  const {setCompletedSessions} = useUserState();
-  const userState = useUserState(state => state.userState);
-
-  const completedSessions = useMemo(
-    () => userState?.completedSessions ?? [],
-    [userState],
-  );
+  const {addCompletedSession} = useUserState();
 
   const hasAudio = Boolean(me?.audioTrack);
   const hasVideo = Boolean(me?.videoTrack);
@@ -140,10 +134,15 @@ const Session = () => {
 
   useEffect(() => {
     if (sessionState?.completed) {
-      setCompletedSessions([...completedSessions, {id: session.id}]);
+      addCompletedSession({id: sessionState?.id});
       logSessionMetricEvent('Complete Sharing Session');
     }
-  }, [sessionState?.completed, logSessionMetricEvent]);
+  }, [
+    sessionState?.completed,
+    sessionState?.id,
+    logSessionMetricEvent,
+    addCompletedSession,
+  ]);
 
   useEffect(() => {
     if (sessionState?.ended) {


### PR DESCRIPTION
Issue: [Notion Task ⛑️](https://www.notion.so/29k/Early-Access-2794500652b34c64b0aff0dbbc53e0ab#7030ff39ac6046ad9aca8ff3d360fe86)

### Description of the Change

We are about to create a new app tab with the user's "Plan", displaying completed sessions and more, so we need to know which sessions the user have participated in to completion.

This change is storing those on async storage, for now it only stores the Session ID, perhaps we should also store a date of when it got completed?

Next steps will be to create that new Tab and display and if necessary fetch more info on those sessions.

#### Video

This video shows the completed session being added on the user's local storage.

https://user-images.githubusercontent.com/7523828/214304262-7c300630-3a4b-4d05-80d7-fcf406fb3c50.mp4




