### PR TITLE
Correct text input config for sign in password

### DIFF
--- a/client/src/routes/SignInModal/SignInModal.tsx
+++ b/client/src/routes/SignInModal/SignInModal.tsx
@@ -68,10 +68,10 @@ const SignInModal = () => {
             defaultValue={email}
           />
           <BottomSheetActionTextInput
-            textContentType="newPassword"
+            textContentType="password"
             secureTextEntry
             autoCapitalize="none"
-            autoComplete="password-new"
+            autoComplete="current-password"
             autoCorrect={false}
             onSubmitEditing={signIn}
             placeholder={t('password')}


### PR DESCRIPTION
On iOS it generated a new password rather than auto completing the current