### PR TITLE
Add GET /sessions/:id endpoint

### DIFF
--- a/client/src/lib/sessions/api/session.ts
+++ b/client/src/lib/sessions/api/session.ts
@@ -71,6 +71,18 @@ export const updateSession = async (
   }
 };
 
+export const getSession = async (id: Session['id']): Promise<Session> => {
+  const response = await apiClient(`${SESSIONS_ENDPOINT}/${id}`, {
+    method: 'GET',
+  });
+
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+
+  return response.json();
+};
+
 export const getSessionToken = async (id: Session['id']): Promise<string> => {
   const response = await apiClient(`${SESSIONS_ENDPOINT}/${id}/sessionToken`, {
     method: 'GET',

--- a/functions/src/api/sessions/index.spec.ts
+++ b/functions/src/api/sessions/index.spec.ts
@@ -24,6 +24,7 @@ const mockUpdateSessionState =
   sessionsController.updateSessionState as jest.Mock;
 const mockJoinSession = sessionsController.joinSession as jest.Mock;
 const mockGetSessionToken = sessionsController.getSessionToken as jest.Mock;
+const mockGetSession = sessionsController.getSession as jest.Mock;
 
 jest.mock('../../models/session');
 
@@ -128,6 +129,57 @@ describe('/api/sessions', () => {
 
       expect(response.status).toBe(403);
       expect(response.text).toEqual(ValidateSessionError.userNotFound);
+    });
+
+    describe('/:id', () => {
+      it('should return session', async () => {
+        mockGetSession.mockResolvedValueOnce({
+          id: 'some-session-id',
+          name: 'some-name',
+          url: 'some-url',
+          hostId: 'some-user-id',
+          startTime: new Date('2022-10-10T10:00:00Z').toISOString(),
+        });
+
+        const response = await request(mockServer).get(
+          '/sessions/some-session-id',
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({
+          id: 'some-session-id',
+          name: 'some-name',
+          url: 'some-url',
+          hostId: 'some-user-id',
+          startTime: expect.any(String),
+        });
+      });
+
+      it('should return 404 if session is not found', async () => {
+        mockGetSession.mockRejectedValueOnce(
+          new RequestError(ValidateSessionError.notFound),
+        );
+
+        const response = await request(mockServer).get(
+          '/sessions/some-session-id',
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.text).toEqual(ValidateSessionError.notFound);
+      });
+
+      it('should return 403 if user is not part of session', async () => {
+        mockGetSession.mockRejectedValueOnce(
+          new RequestError(ValidateSessionError.userNotFound),
+        );
+
+        const response = await request(mockServer).get(
+          '/sessions/some-session-id',
+        );
+
+        expect(response.status).toBe(403);
+        expect(response.text).toEqual(ValidateSessionError.userNotFound);
+      });
     });
   });
 

--- a/functions/src/api/sessions/index.ts
+++ b/functions/src/api/sessions/index.ts
@@ -54,6 +54,31 @@ sessionsRouter.get('/:id/sessionToken', async ctx => {
   }
 });
 
+sessionsRouter.get('/:id', async ctx => {
+  const {user, params} = ctx;
+
+  try {
+    const session = await sessionsController.getSession(user.id, params.id);
+    ctx.status = 200;
+    ctx.body = session;
+  } catch (error) {
+    const requestError = error as RequestError;
+    switch (requestError.code) {
+      case ValidateSessionError.notFound:
+        ctx.status = 404;
+        break;
+
+      case ValidateSessionError.userNotFound:
+        ctx.status = 403;
+        break;
+
+      default:
+        throw error;
+    }
+    ctx.message = requestError.code;
+  }
+});
+
 const CreateSessionSchema = yup.object().shape({
   contentId: yup.string().required(),
   type: yup.mixed<SessionType>().oneOf(Object.values(SessionType)).required(),

--- a/functions/src/controllers/__mocks__/sessions.ts
+++ b/functions/src/controllers/__mocks__/sessions.ts
@@ -6,3 +6,4 @@ export const updateInterestedCount = jest.fn();
 export const updateSessionState = jest.fn();
 export const joinSession = jest.fn();
 export const getSessionToken = jest.fn();
+export const getSession = jest.fn();

--- a/functions/src/controllers/sessions.ts
+++ b/functions/src/controllers/sessions.ts
@@ -51,6 +51,23 @@ export const getSessionToken = async (
   );
 };
 
+export const getSession = async (userId: string, sessionId: Session['id']) => {
+  const session = await sessionModel.getSessionById(sessionId);
+
+  if (!session) {
+    throw new RequestError(ValidateSessionError.notFound);
+  }
+
+  if (
+    session.type === SessionType.private &&
+    !session.userIds.find(id => id === userId)
+  ) {
+    throw new RequestError(ValidateSessionError.userNotFound);
+  }
+
+  return mapSession(session);
+};
+
 export const createSession = async (
   userId: string,
   {


### PR DESCRIPTION
### Description of the Change

I need this endpoint for the upcoming PR adding zustand persist migration from v0 to v1 (including more info on the session) and more.

(Right now `userState` only stores `sessionId` and `completedAt` in `completedSessions`)