### PR TITLE
Add GET /user/:id endpoint

### DIFF
--- a/functions/src/api/user/index.ts
+++ b/functions/src/api/user/index.ts
@@ -1,12 +1,17 @@
 import * as yup from 'yup';
 import validator from 'koa-yup-validator';
+
 import {createApiRouter} from '../../lib/routers';
-import {VerificationError} from '../../../../shared/src/errors/User';
+import {
+  UserProfileError,
+  VerificationError,
+} from '../../../../shared/src/errors/User';
 import {
   requestPublicHostRole,
   verifyPublicHostRequest,
 } from '../../controllers/publicHostRequests';
 import {RequestError} from '../../controllers/errors/RequestError';
+import {getProfile} from '../../controllers/user';
 
 const userRouter = createApiRouter();
 
@@ -77,5 +82,22 @@ userRouter.put(
     }
   },
 );
+
+userRouter.get('/:id', async ctx => {
+  try {
+    const userProfile = await getProfile(ctx.params.id);
+    ctx.body = userProfile;
+  } catch (error) {
+    const requestError = error as RequestError;
+    switch (requestError.code) {
+      case UserProfileError.userNotFound:
+        ctx.status = 404;
+        break;
+      default:
+        throw error;
+    }
+    ctx.message = requestError.code;
+  }
+});
 
 export {userRouter};

--- a/functions/src/controllers/errors/RequestError.ts
+++ b/functions/src/controllers/errors/RequestError.ts
@@ -1,4 +1,7 @@
-import {VerificationError} from '../../../../shared/src/errors/User';
+import {
+  UserProfileError,
+  VerificationError,
+} from '../../../../shared/src/errors/User';
 import {
   JoinSessionError,
   ValidateSessionError,
@@ -6,11 +9,19 @@ import {
 
 export class RequestError extends Error {
   constructor(
-    code: VerificationError | JoinSessionError | ValidateSessionError,
+    code:
+      | VerificationError
+      | JoinSessionError
+      | ValidateSessionError
+      | UserProfileError,
   ) {
     super(code);
     this.code = code;
   }
 
-  code: VerificationError | JoinSessionError | ValidateSessionError;
+  code:
+    | VerificationError
+    | JoinSessionError
+    | ValidateSessionError
+    | UserProfileError;
 }

--- a/functions/src/controllers/user.spec.ts
+++ b/functions/src/controllers/user.spec.ts
@@ -1,0 +1,42 @@
+import * as userModel from '../models/user';
+import {getProfile} from './user';
+
+import {RequestError} from './errors/RequestError';
+import {UserProfileError} from '../../../shared/src/errors/User';
+
+jest.mock('../models/user');
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+});
+
+describe('user - controller', () => {
+  describe('getProfile', () => {
+    it('should get user profile', async () => {
+      const mockedGetPublicUserInfo = jest
+        .mocked(userModel.getPublicUserInfo)
+        .mockResolvedValueOnce({
+          displayName: 'some-name',
+          photoURL: 'some-photo-url',
+        });
+
+      const profile = await getProfile('user-id');
+
+      expect(profile).toEqual({
+        displayName: 'some-name',
+        photoURL: 'some-photo-url',
+      });
+
+      expect(mockedGetPublicUserInfo).toHaveBeenCalledTimes(1);
+      expect(mockedGetPublicUserInfo).toHaveBeenCalledWith('user-id');
+    });
+
+    it('should throw if user not found', async () => {
+      jest.mocked(userModel.getPublicUserInfo).mockResolvedValueOnce({});
+
+      await expect(getProfile('some-non-existing-user-id')).rejects.toEqual(
+        new RequestError(UserProfileError.userNotFound),
+      );
+    });
+  });
+});

--- a/functions/src/controllers/user.ts
+++ b/functions/src/controllers/user.ts
@@ -1,0 +1,13 @@
+import {getPublicUserInfo} from '../models/user';
+import {RequestError} from './errors/RequestError';
+import {UserProfileError} from '../../../shared/src/errors/User';
+
+export const getProfile = async (userId: string) => {
+  const userProfile = await getPublicUserInfo(userId);
+
+  if (!userProfile || (!userProfile.displayName && !userProfile.photoURL)) {
+    throw new RequestError(UserProfileError.userNotFound);
+  }
+
+  return userProfile;
+};

--- a/shared/src/errors/User.ts
+++ b/shared/src/errors/User.ts
@@ -6,3 +6,7 @@ export enum VerificationError {
   verificationAlreadyCalimed = 'verification/already-claimed',
   verificationFailed = 'verification/failed',
 }
+
+export enum UserProfileError {
+  userNotFound = 'userProfile/user-not-found',
+}


### PR DESCRIPTION
### Description of the Change

I need this endpoint to fetch user data for locally (device) stored completed sessions.
This way we do not store any data owned by the user without them being able to delete it and dis-enable others to access such.

