### PR TITLE
Cms support for async

### DIFF
--- a/cms/src/fields/common.ts
+++ b/cms/src/fields/common.ts
@@ -30,6 +30,16 @@ export const PUBLISHED_FIELD: CmsField = {
   hint: "This will make it included in the app. For work in progress, use in combination with hidden and the 'Show work in progress' switch in the app to access it only in staging.",
 };
 
+export const ASYNC_FIELD: CmsField = {
+  label: '🏝 Async',
+  name: 'async',
+  widget: 'boolean',
+  required: false,
+  default: false,
+  i18n: true,
+  hint: 'This will make the exercise available as async',
+};
+
 export const HIDDEN_FIELD: CmsField = {
   label: '🙈 Hidden',
   name: 'hidden',

--- a/cms/src/fields/exercise.ts
+++ b/cms/src/fields/exercise.ts
@@ -15,6 +15,7 @@ import {
   IMAGE_FIELD,
   DESCRIPTION_FIELD,
   TAGS_FIELD,
+  ASYNC_FIELD,
 } from './common';
 import {
   CONTENT_SLIDE,
@@ -137,6 +138,7 @@ const EXERCISE_FIELDS: Array<CmsField> = applyDefaults(
     TAGS_FIELD,
     PUBLISHED_FIELD,
     HIDDEN_FIELD,
+    ASYNC_FIELD,
     SOCIAL_MEDIA,
     CARD_FIELD,
     THEME,

--- a/cms/src/fields/slides.ts
+++ b/cms/src/fields/slides.ts
@@ -8,6 +8,7 @@ import {
 import {
   IMAGE_FIELD,
   LOTTIE_FIELD_WITH_AUDIO,
+  VIDEO_FIELD,
   VIDEO_FIELD_WITH_AUDIO,
 } from './common';
 
@@ -32,8 +33,17 @@ export const HOST_NOTES: CmsFieldBase & CmsFieldList = {
       label: '📝 Text',
       name: 'text',
       widget: 'markdown',
-      required: true,
+      required: false,
       i18n: true,
+      minimal: true,
+    },
+    {
+      label: '🥷 Async Text',
+      name: 'asyncText',
+      widget: 'markdown',
+      required: false,
+      i18n: true,
+      minimal: true,
     },
   ],
 };
@@ -105,7 +115,7 @@ export const HOST_SLIDE: CmsFieldBase & CmsFieldObject = {
   name: SLIDE_TYPES.HOST,
   widget: 'object',
   collapsed: true,
-  fields: [HOST_NOTES],
+  fields: [HOST_NOTES, VIDEO_FIELD],
 };
 
 export const CONTENT_SLIDE: CmsFieldBase & CmsFieldObject = {

--- a/shared/src/types/generated/Exercise.ts
+++ b/shared/src/types/generated/Exercise.ts
@@ -43,7 +43,8 @@ export interface ExerciseIntroPortalVideoEnd {
 }
 
 export interface ExerciseIntroPortalHostNote {
-  text: string;
+  text?: string;
+  asyncText?: string;
 }
 
 export interface ExerciseIntroPortal {
@@ -64,7 +65,8 @@ export interface ExerciseOutroPortal {
 }
 
 export interface ExerciseSlideContentSlideHostNote {
-  text: string;
+  text?: string;
+  asyncText?: string;
 }
 
 export interface ExerciseSlideContentSlideContentImage {
@@ -99,7 +101,8 @@ export interface ExerciseSlideContentSlideContent {
 }
 
 export interface ExerciseSlideReflectionSlideHostNote {
-  text: string;
+  text?: string;
+  asyncText?: string;
 }
 
 export interface ExerciseSlideReflectionSlideContentImage {
@@ -134,7 +137,8 @@ export interface ExerciseSlideReflectionSlideContent {
 }
 
 export interface ExerciseSlideSharingSlideHostNote {
-  text: string;
+  text?: string;
+  asyncText?: string;
 }
 
 export interface ExerciseSlideSharingSlideContentImage {
@@ -169,7 +173,14 @@ export interface ExerciseSlideSharingSlideContent {
 }
 
 export interface ExerciseSlideHostSlideHostNote {
-  text: string;
+  text?: string;
+  asyncText?: string;
+}
+
+export interface ExerciseSlideHostSlideVideo {
+  description?: string;
+  source?: string;
+  preview?: string;
 }
 
 export interface ExerciseSlideContentSlide {
@@ -193,6 +204,7 @@ export interface ExerciseSlideSharingSlide {
 export interface ExerciseSlideHostSlide {
   type: 'host';
   hostNotes?: ExerciseSlideHostSlideHostNote[];
+  video?: ExerciseSlideHostSlideVideo;
 }
 
 export interface Exercise {
@@ -203,6 +215,7 @@ export interface Exercise {
   tags?: any[];
   published: boolean;
   hidden?: boolean;
+  async?: boolean;
   socialMeta?: ExerciseSocialMediaMetaTags;
   card: ExerciseCard;
   theme?: ExerciseTheme;


### PR DESCRIPTION
CMS part of #1632 so we can start creating content before releasing. Adds a flag to toggle async on and off, will add filters on this on #1632 so we can release it without needing to prepare all exercises at once  
