### PR TITLE
Remove duplicate UUID packages

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -68,7 +68,6 @@
     "react-native-shared-element": "^0.8.8",
     "react-native-sound": "https://github.com/29ki/react-native-sound#fix-iOS-16-support",
     "react-native-svg": "^13.7.0",
-    "react-native-uuid": "^2.0.1",
     "react-native-video": "https://github.com/29ki/react-native-video-5.2.1#repeat-ios-using-av-player-looper",
     "react-navigation-shared-element": "^3.1.3",
     "styled-components": "^5.3.6",

--- a/client/src/lib/metrics/adaptors/backEnd/utils/getMetricsUid.spec.ts
+++ b/client/src/lib/metrics/adaptors/backEnd/utils/getMetricsUid.spec.ts
@@ -1,9 +1,9 @@
-import * as uuid from 'uuid';
 import {FirebaseAuthTypes} from '@react-native-firebase/auth';
 import useUserState from '../../../../user/state/state';
 import getMetricsUid from './getMetricsUid';
+import {generateId} from '../../../../utils/id';
 
-jest.mock('uuid');
+jest.mock('../../../../utils/id');
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -24,7 +24,7 @@ describe('getMetricsUid', () => {
   });
 
   it('generates a new if no metricsUid is set', () => {
-    jest.mocked(uuid.v4).mockReturnValueOnce('some-uuid');
+    jest.mocked(generateId).mockReturnValueOnce('some-uuid');
     useUserState.setState({
       user: {uid: 'some-user-id'} as FirebaseAuthTypes.User,
       userState: {},

--- a/client/src/lib/metrics/adaptors/backEnd/utils/getMetricsUid.ts
+++ b/client/src/lib/metrics/adaptors/backEnd/utils/getMetricsUid.ts
@@ -1,7 +1,7 @@
-import * as uuid from 'uuid';
 import useUserState, {
   getCurrentUserStateSelector,
 } from '../../../../user/state/state';
+import {generateId} from '../../../../utils/id';
 
 const getMetricsUid = () => {
   const state = useUserState.getState();
@@ -14,7 +14,7 @@ const getMetricsUid = () => {
       return uid;
     }
 
-    const newUid = uuid.v4();
+    const newUid = generateId();
 
     setCurrentUserState({metricsUid: newUid});
 

--- a/client/src/lib/utils/id.ts
+++ b/client/src/lib/utils/id.ts
@@ -1,3 +1,3 @@
-import uuid from 'react-native-uuid';
+import uuid from 'uuid';
 
-export const generateId = () => uuid.v4().toString();
+export const generateId = () => uuid.v4();

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8278,11 +8278,6 @@ react-native-url-polyfill@^1.1.2:
   dependencies:
     whatwg-url-without-unicode "8.0.0-3"
 
-react-native-uuid@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-uuid/-/react-native-uuid-2.0.1.tgz#ed4e2dfb1683eddb66967eb5dca140dfe1abddb9"
-  integrity sha512-cptnoIbL53GTCrWlb/+jrDC6tvb7ypIyzbXNJcpR3Vab0mkeaaVd5qnB3f0whXYzS+SMoSQLcUUB0gEWqkPC0g==
-
 "react-native-video@https://github.com/29ki/react-native-video-5.2.1#repeat-ios-using-av-player-looper":
   version "5.2.1"
   resolved "https://github.com/29ki/react-native-video-5.2.1#dcc98b0963c145c201bde7244e03de7a2385dae7"


### PR DESCRIPTION
Removes `react-native-uuid` in favour of `react-native-get-random-values`