### PR TITLE
Set default fill on SVG icons

### DIFF
--- a/client/src/lib/components/Icons/Icon.tsx
+++ b/client/src/lib/components/Icons/Icon.tsx
@@ -7,7 +7,12 @@ const SvgIcon = styled(Svg)({
 });
 
 const Icon: React.FC<SvgProps> = ({children, style}) => (
-  <SvgIcon width="100%" height="100%" viewBox="0 0 30 30" style={style}>
+  <SvgIcon
+    width="100%"
+    height="100%"
+    viewBox="0 0 30 30"
+    style={style}
+    fill="transparent">
     {children}
   </SvgIcon>
 );


### PR DESCRIPTION
Default fill color for SVGs was [restored to black](https://github.com/software-mansion/react-native-svg/pull/1947) in [`react-native-svg@13.7.0`](https://github.com/software-mansion/react-native-svg/releases/tag/v13.7.0)

Mostly noticeable on checkmark, arrow left and logotype that has non-closed paths:
| Before | After |
|-|-|
| <img width="341" alt="image" src="https://user-images.githubusercontent.com/474066/216954764-8a8bca03-4a39-428e-8608-6161a99338fb.png"> | <img width="337" alt="image" src="https://user-images.githubusercontent.com/474066/216954667-40ab4082-0f46-46d4-a936-663f26a958ee.png"> |