### PR TITLE
Fix autoComplete value

### DIFF
--- a/client/src/routes/SignInModal/SignInModal.tsx
+++ b/client/src/routes/SignInModal/SignInModal.tsx
@@ -71,7 +71,7 @@ const SignInModal = () => {
             textContentType="password"
             secureTextEntry
             autoCapitalize="none"
-            autoComplete="current-password"
+            autoComplete="password"
             autoCorrect={false}
             onSubmitEditing={signIn}
             placeholder={t('password')}


### PR DESCRIPTION
`autoComplete="current-password"` isn't introduced until RN `0.71` :P 
https://reactnative.dev/docs/textinput#autocomplete

Closes #1738