### PR TITLE
Update future sessions cards to 'stand alone'

### DIFF
--- a/client/src/routes/Journey/Journey.tsx
+++ b/client/src/routes/Journey/Journey.tsx
@@ -33,7 +33,7 @@ import styled from 'styled-components/native';
 export type Section = {
   title: string;
   data: JourneySession[];
-  type: 'interested' | 'completed' | 'hosted';
+  type: 'planned' | 'completed';
 };
 
 const SectionList = RNSectionList<JourneySession, Section>;
@@ -56,7 +56,6 @@ const renderSession: SectionListRenderItem<JourneySession, Section> = ({
   item,
   index,
 }) => {
-  const standAlone = section.data.length === 1;
   const hasCardBefore = index > 0;
   const hasCardAfter = index !== section.data.length - 1;
 
@@ -73,7 +72,7 @@ const renderSession: SectionListRenderItem<JourneySession, Section> = ({
       <Gutters>
         <SessionCard
           session={item as Session}
-          standAlone={standAlone}
+          standAlone={true}
           hasCardBefore={hasCardBefore}
           hasCardAfter={hasCardAfter}
         />
@@ -99,19 +98,11 @@ const Journey = () => {
       });
     }
 
-    if (hostedSessions.length > 0) {
+    if (hostedSessions.length > 0 || pinnedSessions.length > 0) {
       sectionsList.push({
-        title: t('headings.hosted'),
-        data: hostedSessions,
-        type: 'hosted',
-      });
-    }
-
-    if (pinnedSessions.length > 0) {
-      sectionsList.push({
-        title: t('headings.interested'),
-        data: pinnedSessions,
-        type: 'interested',
+        title: t('headings.planned'),
+        data: [...hostedSessions, ...pinnedSessions],
+        type: 'planned',
       });
     }
 
@@ -137,7 +128,7 @@ const Journey = () => {
     return (
       <Screen backgroundColor={COLORS.GREYLIGHTEST}>
         <Container>
-          <Display24>{'🌱 Your journey has just begun'}</Display24>
+          <Display24>{t('fallback')}</Display24>
         </Container>
       </Screen>
     );

--- a/content/src/ui/Screen.Journey.json
+++ b/content/src/ui/Screen.Journey.json
@@ -2,9 +2,9 @@
   "en": {
     "headings": {
       "completed": "Completed",
-      "hosted": "Your sessions",
-      "interested": "Interested"
-    }
+      "planned": "Your planned sessions"
+    },
+    "fallback": "🌱 Your journey has just begun"
   },
   "pt": {},
   "sv": {},


### PR DESCRIPTION
### Description of the Change

Sessions are grouped under two groups: 
- Past ("Completed")
- Future (”Your planned sessions")

Future cards are always "expanded" (full-size).