### PR TITLE
Adjust journey scroll offset

### DIFF
--- a/client/src/routes/Journey/Journey.tsx
+++ b/client/src/routes/Journey/Journey.tsx
@@ -101,7 +101,11 @@ const Journey = () => {
     if (completedSessions.length > 0) {
       sectionsList.push({
         title: t('headings.completed'),
-        data: completedSessions.map(s => ({...s, __type: 'completed'})),
+        data: completedSessions
+          .sort((a, b) =>
+            dayjs(a.completedAt).isAfter(dayjs(b.completedAt)) ? -1 : 1,
+          )
+          .map(s => ({...s, __type: 'completed'})),
         type: 'completed',
       });
     }
@@ -164,7 +168,7 @@ const Journey = () => {
         listRef.current?.scrollToLocation({
           itemIndex: 0,
           sectionIndex: 1,
-          viewOffset: 50,
+          viewOffset: 380,
         }),
       );
     }


### PR DESCRIPTION
Tested on Android only...

Could @gewfy or @swemail test it on ios as well?

Should scroll to such to a position like this:

<img src="https://user-images.githubusercontent.com/7523828/218542469-f0083401-f466-45c9-bd72-684dbbc4057b.png" width="400" />
