### PR TITLE
Remove unecessary completed session sorting on Joruney

### DIFF
--- a/client/src/routes/Journey/Journey.tsx
+++ b/client/src/routes/Journey/Journey.tsx
@@ -101,11 +101,7 @@ const Journey = () => {
     if (completedSessions.length > 0) {
       sectionsList.push({
         title: t('headings.completed'),
-        data: completedSessions
-          .sort((a, b) =>
-            dayjs(a.completedAt).isAfter(dayjs(b.completedAt)) ? -1 : 1,
-          )
-          .map(s => ({...s, __type: 'completed'})),
+        data: completedSessions.map(s => ({...s, __type: 'completed'})),
         type: 'completed',
       });
     }


### PR DESCRIPTION
I added this sorting not long ago thinking it was necessary but it was actually a brain fart 😂 
the completed sessions will already naturally be in order of completion (oldest first, closer to "now" in the bottom)

Exactly as by design, so the sorting isn't needed at all at the moment 😬 
