### PR TITLE
Add Re-auth modal for user deletion

### DIFF
--- a/client/src/lib/navigation/ModalStack.tsx
+++ b/client/src/lib/navigation/ModalStack.tsx
@@ -27,6 +27,7 @@ import ContactModal from '../../routes/ConcactModal/ContactModal';
 import SessionFeedbackModal from '../../routes/SessionFeedbackModal/SessionFeedbackModal';
 import SharingModal from '../../routes/SharingModal/SharingModal';
 import SharingPostModal from '../../routes/SharingPostModal/SharingPostModal';
+import DeleteUserModal from '../../routes/DeleteUserModal/DeleteUserModal';
 
 const {Navigator, Screen, Group} =
   createBottomSheetNavigator<ModalStackProps>();
@@ -174,6 +175,12 @@ const ModalStack = () => {
         <Screen
           name={'SignInModal'}
           component={SignInModal}
+          options={shortSheetModalScreenOptions}
+        />
+
+        <Screen
+          name={'DeleteUserModal'}
+          component={DeleteUserModal}
           options={shortSheetModalScreenOptions}
         />
 

--- a/client/src/lib/navigation/constants/routes.ts
+++ b/client/src/lib/navigation/constants/routes.ts
@@ -66,6 +66,7 @@ export type ModalStackProps = {
   ChangeLanguageModal: undefined;
   ProfileSettingsModal: undefined;
   SignInModal: undefined;
+  DeleteUserModal: undefined;
   ContributorsModal: undefined;
   PartnersModal: undefined;
   DeveloperModal: undefined;

--- a/client/src/routes/DeleteUserModal/DeleteUserModal.tsx
+++ b/client/src/routes/DeleteUserModal/DeleteUserModal.tsx
@@ -36,9 +36,9 @@ const DeleteUserModal = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
-  const {deleteUser} = useDeleteUser();
+  const {deleteUser, isDeletingUser} = useDeleteUser();
 
-  const signIn = useCallback(async () => {
+  const onConfirm = useCallback(async () => {
     try {
       setIsSigningIn(true);
       await auth().signInWithEmailAndPassword(email, password);
@@ -63,7 +63,7 @@ const DeleteUserModal = () => {
             autoCapitalize="none"
             autoComplete="email"
             autoCorrect={false}
-            onSubmitEditing={signIn}
+            onSubmitEditing={onConfirm}
             placeholder={t('email')}
             onChangeText={setEmail}
             defaultValue={email}
@@ -74,7 +74,7 @@ const DeleteUserModal = () => {
             autoCapitalize="none"
             autoComplete="password"
             autoCorrect={false}
-            onSubmitEditing={signIn}
+            onSubmitEditing={onConfirm}
             placeholder={t('password')}
             onChangeText={setPassword}
           />
@@ -88,10 +88,10 @@ const DeleteUserModal = () => {
         )}
         <StyledButton
           variant="primary"
-          disabled={isSigningIn || !email || !password}
-          loading={isSigningIn}
-          onPress={signIn}>
-          {t('signIn')}
+          disabled={isSigningIn || isDeletingUser || !email || !password}
+          loading={isSigningIn || isDeletingUser}
+          onPress={onConfirm}>
+          {t('confirm')}
         </StyledButton>
       </Gutters>
     </SheetModal>

--- a/client/src/routes/DeleteUserModal/DeleteUserModal.tsx
+++ b/client/src/routes/DeleteUserModal/DeleteUserModal.tsx
@@ -18,9 +18,14 @@ import {Spacer16, Spacer24} from '../../lib/components/Spacers/Spacer';
 import {ModalHeading} from '../../lib/components/Typography/Heading/Heading';
 import {BottomSheetActionTextInput} from '../../lib/components/ActionList/ActionItems/ActionTextInput';
 import {Body16} from '../../lib/components/Typography/Body/Body';
+import {SPACINGS} from '../../lib/constants/spacings';
 
 const StyledButton = styled(Button)({
   alignSelf: 'flex-start',
+});
+
+const Row = styled.View({
+  padding: SPACINGS.SIXTEEN,
 });
 
 const Error = styled(Body16)({
@@ -33,13 +38,16 @@ const DeleteUserModal = () => {
     useNavigation<NativeStackNavigationProp<ModalStackProps>>();
 
   const [isSigningIn, setIsSigningIn] = useState(false);
-  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const {deleteUser, isDeletingUser} = useDeleteUser();
 
   const onConfirm = useCallback(async () => {
     try {
+      const email = auth().currentUser?.email;
+      if (!email) {
+        return;
+      }
       setIsSigningIn(true);
       await auth().signInWithEmailAndPassword(email, password);
       setIsSigningIn(false);
@@ -49,7 +57,7 @@ const DeleteUserModal = () => {
       setIsSigningIn(false);
       setError(e.code ?? e.message);
     }
-  }, [setIsSigningIn, popToTop, deleteUser, email, password]);
+  }, [setIsSigningIn, popToTop, deleteUser, password]);
 
   return (
     <SheetModal>
@@ -57,17 +65,10 @@ const DeleteUserModal = () => {
         <ModalHeading>{t('title')}</ModalHeading>
         <Spacer24 />
         <ActionList>
-          <BottomSheetActionTextInput
-            textContentType="emailAddress"
-            keyboardType="email-address"
-            autoCapitalize="none"
-            autoComplete="email"
-            autoCorrect={false}
-            onSubmitEditing={onConfirm}
-            placeholder={t('email')}
-            onChangeText={setEmail}
-            defaultValue={email}
-          />
+          <Row>
+            <Body16>{auth().currentUser?.email}</Body16>
+          </Row>
+
           <BottomSheetActionTextInput
             textContentType="password"
             secureTextEntry
@@ -88,7 +89,7 @@ const DeleteUserModal = () => {
         )}
         <StyledButton
           variant="primary"
-          disabled={isSigningIn || isDeletingUser || !email || !password}
+          disabled={isSigningIn || isDeletingUser || !password}
           loading={isSigningIn || isDeletingUser}
           onPress={onConfirm}>
           {t('confirm')}

--- a/client/src/routes/DeleteUserModal/DeleteUserModal.tsx
+++ b/client/src/routes/DeleteUserModal/DeleteUserModal.tsx
@@ -1,21 +1,23 @@
 import React, {useCallback, useState} from 'react';
+import {useNavigation} from '@react-navigation/native';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components/native';
 import auth from '@react-native-firebase/auth';
 
-import {BottomSheetActionTextInput} from '../../lib/components/ActionList/ActionItems/ActionTextInput';
+import {ModalStackProps} from '../../lib/navigation/constants/routes';
+import {COLORS} from '../../../../shared/src/constants/colors';
+
+import useDeleteUser from '../../lib/user/hooks/useDeleteUser';
+
 import ActionList from '../../lib/components/ActionList/ActionList';
 import Button from '../../lib/components/Buttons/Button';
-
 import Gutters from '../../lib/components/Gutters/Gutters';
 import SheetModal from '../../lib/components/Modals/SheetModal';
 import {Spacer16, Spacer24} from '../../lib/components/Spacers/Spacer';
 import {ModalHeading} from '../../lib/components/Typography/Heading/Heading';
-import {useNavigation} from '@react-navigation/native';
-import {NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {ModalStackProps} from '../../lib/navigation/constants/routes';
+import {BottomSheetActionTextInput} from '../../lib/components/ActionList/ActionItems/ActionTextInput';
 import {Body16} from '../../lib/components/Typography/Body/Body';
-import {COLORS} from '../../../../shared/src/constants/colors';
 
 const StyledButton = styled(Button)({
   alignSelf: 'flex-start',
@@ -25,8 +27,8 @@ const Error = styled(Body16)({
   color: COLORS.ERROR,
 });
 
-const SignInModal = () => {
-  const {t} = useTranslation('Modal.SignIn');
+const DeleteUserModal = () => {
+  const {t} = useTranslation('Modal.DeleteUser');
   const {popToTop} =
     useNavigation<NativeStackNavigationProp<ModalStackProps>>();
 
@@ -34,18 +36,20 @@ const SignInModal = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const {deleteUser} = useDeleteUser();
 
   const signIn = useCallback(async () => {
     try {
       setIsSigningIn(true);
       await auth().signInWithEmailAndPassword(email, password);
       setIsSigningIn(false);
+      await deleteUser();
       popToTop();
     } catch (e: any) {
       setIsSigningIn(false);
       setError(e.code ?? e.message);
     }
-  }, [setIsSigningIn, popToTop, email, password]);
+  }, [setIsSigningIn, popToTop, deleteUser, email, password]);
 
   return (
     <SheetModal>
@@ -94,4 +98,4 @@ const SignInModal = () => {
   );
 };
 
-export default SignInModal;
+export default DeleteUserModal;

--- a/client/src/routes/Profile/Profile.tsx
+++ b/client/src/routes/Profile/Profile.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components/native';
 import {ENVIRONMENT} from 'config';
+import auth from '@react-native-firebase/auth';
 
 import Gutters from '../../lib/components/Gutters/Gutters';
 import {
@@ -123,6 +124,14 @@ const Profile = () => {
     [navigate],
   );
 
+  const deleteDataPress = useCallback(async () => {
+    if (auth().currentUser?.isAnonymous) {
+      await deleteUser();
+    } else {
+      navigate('DeleteUserModal');
+    }
+  }, [deleteUser, navigate]);
+
   return (
     <Screen>
       <TopSafeArea />
@@ -161,7 +170,7 @@ const Profile = () => {
             <>
               <Spacer16 />
               <ActionList>
-                <ActionButton Icon={DeleteIcon} onPress={deleteUser}>
+                <ActionButton Icon={DeleteIcon} onPress={deleteDataPress}>
                   {t('actions.deleteData')}
                 </ActionButton>
               </ActionList>

--- a/client/src/routes/ProfileSettingsModal/ProfileSettingsModal.tsx
+++ b/client/src/routes/ProfileSettingsModal/ProfileSettingsModal.tsx
@@ -46,7 +46,7 @@ const Error = styled(Body16)({
 
 const ProfileSettingsModal = () => {
   const {t} = useTranslation('Modal.ProfileSettings');
-  const {popToTop} =
+  const {popToTop, navigate} =
     useNavigation<NativeStackNavigationProp<ModalStackProps>>();
   const {changeProfilePicture, isUpdatingProfilePicture} =
     useChangeProfilePicture();
@@ -84,13 +84,16 @@ const ProfileSettingsModal = () => {
 
   const deleteData = useCallback(async () => {
     try {
-      if (await deleteUser()) {
+      if (auth().currentUser?.isAnonymous) {
+        await deleteUser();
         popToTop();
+      } else {
+        navigate('DeleteUserModal');
       }
     } catch (e: any) {
       setError(e.code ?? e.message);
     }
-  }, [deleteUser, popToTop]);
+  }, [navigate, popToTop, deleteUser]);
 
   return (
     <SheetModal>

--- a/content/src/ui/Modal.DeleteUser.json
+++ b/content/src/ui/Modal.DeleteUser.json
@@ -1,0 +1,26 @@
+{
+  "en": {
+    "title": "Authenticate to delete your data",
+    "email": "E-mail",
+    "password": "Password",
+    "signIn": "Confirm",
+    "errors": {
+      "auth/invalid-email": "Wrong e-mail and/or password",
+      "auth/wrong-password": "Wrong e-mail and/or password",
+      "auth/user-not-found": "Wrong e-mail and/or password",
+      "auth/user-disabled": "Wrong e-mail and/or password"
+    }
+  },
+  "pt": {
+    "email": "Email",
+    "password": "Password",
+    "errors": {
+      "auth/invalid-email": "Email e/ou password errada",
+      "auth/wrong-password": "Email e/ou password errada",
+      "auth/user-not-found": "Email não existe",
+      "auth/user-disabled": "Email inativo"
+    }
+  },
+  "sv": {},
+  "es": {}
+}


### PR DESCRIPTION
[Notion Task](https://www.notion.so/29k/Early-Access-2794500652b34c64b0aff0dbbc53e0ab?pvs=4#ddb01980a58642e899304189ce46fa15)

### Description of the Change

As a user when deleting your data, you should re-authenticate to both confirm your choice (UX) and so the session hasn't "expired" (tech).

Unless you're an anonymous user, then you don't need to authenticate.

#### Screenshots



https://user-images.githubusercontent.com/7523828/220126570-746f0259-0e5b-4216-a04c-41497cf757d6.mov

