### PR TITLE
Fix bug where host could not rejoin

### DIFF
--- a/client/src/lib/daily/DailyProvider.tsx
+++ b/client/src/lib/daily/DailyProvider.tsx
@@ -60,19 +60,19 @@ const DailyProvider: React.FC<{children: React.ReactNode}> = ({children}) => {
     const onParticipantJoined = ({
       participant,
     }: DailyEventObject<'participant-joined'>) => {
-      setParticipant(participant.user_id, participant);
+      setParticipant(participant.session_id, participant);
     };
 
     const onParticipantUpdated = ({
       participant,
     }: DailyEventObject<'participant-updated'>) => {
-      setParticipant(participant.user_id, participant);
+      setParticipant(participant.session_id, participant);
     };
 
     const onParticipantLeft = ({
       participant,
     }: DailyEventObject<'participant-left'>) => {
-      removeParticipant(participant.user_id);
+      removeParticipant(participant.session_id);
     };
 
     const onActiveSpeakerChange = ({

--- a/client/src/lib/daily/state/state.spec.ts
+++ b/client/src/lib/daily/state/state.spec.ts
@@ -9,13 +9,14 @@ describe('Daily state', () => {
       const {result} = renderHook(() => useDailyState());
 
       act(() => {
-        result.current.setParticipant('some-id', {
+        result.current.setParticipant('some-session-id', {
           user_id: 'some-id',
+          session_id: 'some-session-id',
         } as DailyParticipant);
       });
 
       expect(result.current.participants).toEqual({
-        'some-id': {user_id: 'some-id'},
+        'some-session-id': {user_id: 'some-id', session_id: 'some-session-id'},
       });
     });
   });
@@ -24,20 +25,20 @@ describe('Daily state', () => {
     it('should change order if participant is not first or second', () => {
       useDailyState.setState({
         participants: {
-          'user-1': {
+          'session-id-1': {
             session_id: 'session-id-1',
             user_id: 'user-1',
           } as DailyParticipant,
-          'user-2': {
+          'session-id-2': {
             session_id: 'session-id-2',
             user_id: 'user-2',
           } as DailyParticipant,
-          'user-3': {
+          'session-id-3': {
             session_id: 'session-id-3',
             user_id: 'user-3',
           } as DailyParticipant,
         },
-        participantsSortOrder: ['user-1', 'user-2'],
+        participantsSortOrder: ['session-id-1', 'session-id-2'],
       });
       const {result} = renderHook(() => useDailyState());
 
@@ -46,29 +47,29 @@ describe('Daily state', () => {
       });
 
       expect(result.current.participantsSortOrder).toEqual([
-        'user-3',
-        'user-1',
-        'user-2',
+        'session-id-3',
+        'session-id-1',
+        'session-id-2',
       ]);
     });
 
     it('should not change order if participant is already first', () => {
       useDailyState.setState({
         participants: {
-          'user-1': {
+          'session-id-1': {
             session_id: 'session-id-1',
             user_id: 'user-1',
           } as DailyParticipant,
-          'user-2': {
+          'session-id-2': {
             session_id: 'session-id-2',
             user_id: 'user-2',
           } as DailyParticipant,
-          'user-3': {
+          'session-id-3': {
             session_id: 'session-id-3',
             user_id: 'user-3',
           } as DailyParticipant,
         },
-        participantsSortOrder: ['user-1', 'user-2'],
+        participantsSortOrder: ['session-id-1', 'session-id-2'],
       });
       const {result} = renderHook(() => useDailyState());
 
@@ -77,28 +78,28 @@ describe('Daily state', () => {
       });
 
       expect(result.current.participantsSortOrder).toEqual([
-        'user-1',
-        'user-2',
+        'session-id-1',
+        'session-id-2',
       ]);
     });
 
     it('should not change order if participant is already second', () => {
       useDailyState.setState({
         participants: {
-          'user-1': {
+          'session-id-1': {
             session_id: 'session-id-1',
             user_id: 'user-1',
           } as DailyParticipant,
-          'user-2': {
+          'session-id-2': {
             session_id: 'session-id-2',
             user_id: 'user-2',
           } as DailyParticipant,
-          'user-3': {
+          'session-id-3': {
             session_id: 'session-id-3',
             user_id: 'user-3',
           } as DailyParticipant,
         },
-        participantsSortOrder: ['user-1', 'user-2'],
+        participantsSortOrder: ['session-id-1', 'session-id-2'],
       });
       const {result} = renderHook(() => useDailyState());
 
@@ -107,8 +108,8 @@ describe('Daily state', () => {
       });
 
       expect(result.current.participantsSortOrder).toEqual([
-        'user-1',
-        'user-2',
+        'session-id-1',
+        'session-id-2',
       ]);
     });
   });
@@ -117,26 +118,33 @@ describe('Daily state', () => {
     it('removed from participants and participantsSortOrder states', () => {
       useDailyState.setState({
         participants: {
-          'some-id': {
+          'some-session-id': {
             user_id: 'some-id',
+            session_id: 'some-session-id',
           } as DailyParticipant,
-          'some-other-id': {
+          'some-other-session-id': {
             user_id: 'some-other-id',
+            session_id: 'some-other-session-id',
           } as DailyParticipant,
         },
-        participantsSortOrder: ['some-id', 'some-other-id'],
+        participantsSortOrder: ['some-session-id', 'some-other-session-id'],
       });
 
       const {result} = renderHook(() => useDailyState());
 
       act(() => {
-        result.current.removeParticipant('some-id');
+        result.current.removeParticipant('some-session-id');
       });
 
       expect(result.current.participants).toEqual({
-        'some-other-id': {user_id: 'some-other-id'},
+        'some-other-session-id': {
+          user_id: 'some-other-id',
+          session_id: 'some-other-session-id',
+        },
       });
-      expect(result.current.participantsSortOrder).toEqual(['some-other-id']);
+      expect(result.current.participantsSortOrder).toEqual([
+        'some-other-session-id',
+      ]);
     });
   });
 
@@ -144,14 +152,16 @@ describe('Daily state', () => {
     it('resets state to inital state', () => {
       useDailyState.setState({
         participants: {
-          'some-id': {
+          'some-session-id': {
             user_id: 'some-id',
+            session_id: 'some-session-id',
           } as DailyParticipant,
-          'some-other-id': {
+          'some-other-session-id': {
             user_id: 'some-other-id',
+            session_id: 'some-other-session-id',
           } as DailyParticipant,
         },
-        participantsSortOrder: ['some-id', 'some-other-id'],
+        participantsSortOrder: ['some-session-id', 'some-other-session-id'],
       });
 
       const {result} = renderHook(() => useDailyState());

--- a/client/src/lib/daily/state/state.ts
+++ b/client/src/lib/daily/state/state.ts
@@ -4,7 +4,7 @@ import {create} from 'zustand';
 
 type State = {
   participants: {
-    [user_id: string]: DailyParticipant;
+    [session_id: string]: DailyParticipant;
   };
   participantsSortOrder: string[];
 };
@@ -39,24 +39,17 @@ const useDailyState = create<State & Actions>()((set, get) => ({
     })),
 
   setParticipantsSortOrder: sessionId => {
-    const {participants, participantsSortOrder} = get();
-    const participantsList = Object.values(participants);
-    const userId = participantsList.find(
-      p => p.session_id === sessionId,
-    )?.user_id;
-
-    if (userId) {
-      if (
-        userId !== participantsSortOrder[0] &&
-        userId !== participantsSortOrder[1]
-      ) {
-        set({
-          participantsSortOrder: [
-            userId,
-            ...without([userId], participantsSortOrder),
-          ],
-        });
-      }
+    const {participantsSortOrder} = get();
+    if (
+      sessionId !== participantsSortOrder[0] &&
+      sessionId !== participantsSortOrder[1]
+    ) {
+      set({
+        participantsSortOrder: [
+          sessionId,
+          ...without([sessionId], participantsSortOrder),
+        ],
+      });
     }
   },
 

--- a/client/src/lib/session/components/Participants/Participants.tsx
+++ b/client/src/lib/session/components/Participants/Participants.tsx
@@ -39,7 +39,7 @@ const Participants: React.FC<ParticipantsProps> = ({
     <Container>
       {participants.map((participant, i) => (
         <StyledParticipant
-          key={participant.user_id}
+          key={participant.session_id}
           participant={participant}
           height={participantHeight}
           // Last and odd participant - stump

--- a/client/src/lib/session/hooks/useIsSessionHost.ts
+++ b/client/src/lib/session/hooks/useIsSessionHost.ts
@@ -1,8 +1,12 @@
-import useSessionHost from './useSessionHost';
+import {useMemo} from 'react';
+import useDailyState from '../../daily/state/state';
 
 const useIsSessionHost = () => {
-  const host = useSessionHost();
-  return Boolean(host?.local);
+  const participants = useDailyState(state => state.participants);
+
+  return useMemo(() => {
+    return Boolean(Object.values(participants).find(p => p.owner && p.local));
+  }, [participants]);
 };
 
 export default useIsSessionHost;

--- a/client/src/lib/session/hooks/useSessionHost.spec.ts
+++ b/client/src/lib/session/hooks/useSessionHost.spec.ts
@@ -7,8 +7,8 @@ describe('useSessionHost', () => {
   it('returns the host', () => {
     useDailyState.setState({
       participants: {
-        'some-spotlight-user-id': {
-          user_id: 'some-spotlight-user-id',
+        'some-spotlight-session-id': {
+          session_id: 'some-spotlight-session-id',
           owner: true,
         } as DailyParticipant,
       },
@@ -17,7 +17,7 @@ describe('useSessionHost', () => {
     const {result} = renderHook(() => useSessionHost());
 
     expect(result.current).toEqual({
-      user_id: 'some-spotlight-user-id',
+      session_id: 'some-spotlight-session-id',
       owner: true,
     });
   });
@@ -25,8 +25,8 @@ describe('useSessionHost', () => {
   it('returns undefined when no host is found', () => {
     useDailyState.setState({
       participants: {
-        'some-spotlight-user-id': {
-          user_id: 'some-spotlight-user-id',
+        'some-spotlight-session-id': {
+          session_id: 'some-spotlight-session-id',
           owner: false,
         } as DailyParticipant,
       },

--- a/client/src/lib/session/hooks/useSessionParticipants.spec.ts
+++ b/client/src/lib/session/hooks/useSessionParticipants.spec.ts
@@ -10,11 +10,11 @@ const mockUseSessionSlideState = useSessionSlideState as jest.Mock;
 jest.mock('./useSessionSlideState');
 
 const createParticipant = (
-  id: string,
+  session_id: string,
   userData?: DailyUserData,
   owner = false,
 ) => ({
-  [id]: {user_id: id, owner, userData} as DailyParticipant,
+  [session_id]: {session_id, owner, userData} as DailyParticipant,
 });
 
 describe('useSessionParticipants', () => {
@@ -31,9 +31,9 @@ describe('useSessionParticipants', () => {
     const {result} = renderHook(() => useSessionParticipants());
 
     expect(result.current).toEqual([
-      {user_id: 'test-id-2', owner: false},
-      {user_id: 'test-id-3', owner: false},
-      {user_id: 'test-id-1', owner: false},
+      {session_id: 'test-id-2', owner: false},
+      {session_id: 'test-id-3', owner: false},
+      {session_id: 'test-id-1', owner: false},
     ]);
   });
 
@@ -44,15 +44,15 @@ describe('useSessionParticipants', () => {
 
     useDailyState.setState({
       participants: {
-        ...createParticipant('some-spotlight-user-id', undefined, true),
-        ...createParticipant('some-other-user-id'),
+        ...createParticipant('some-spotlight-session-id', undefined, true),
+        ...createParticipant('some-other-session-id'),
       },
     });
 
     const {result} = renderHook(() => useSessionParticipants());
 
     expect(result.current).toEqual([
-      {user_id: 'some-other-user-id', owner: false},
+      {session_id: 'some-other-session-id', owner: false},
     ]);
   });
 
@@ -63,16 +63,16 @@ describe('useSessionParticipants', () => {
 
     useDailyState.setState({
       participants: {
-        ...createParticipant('some-user-id'),
-        ...createParticipant('some-other-user-id'),
+        ...createParticipant('some-session-id'),
+        ...createParticipant('some-other-session-id'),
       },
     });
 
     const {result} = renderHook(() => useSessionParticipants());
 
     expect(result.current).toEqual([
-      {user_id: 'some-user-id', owner: false},
-      {user_id: 'some-other-user-id', owner: false},
+      {session_id: 'some-session-id', owner: false},
+      {session_id: 'some-other-session-id', owner: false},
     ]);
   });
 
@@ -83,25 +83,27 @@ describe('useSessionParticipants', () => {
 
     useDailyState.setState({
       participants: {
-        ...createParticipant('some-spotlight-user-id', undefined, true),
-        ...createParticipant('some-other-user-id'),
+        ...createParticipant('some-spotlight-session-id', undefined, true),
+        ...createParticipant('some-other-session-id'),
       },
     });
 
     const {result} = renderHook(() => useSessionParticipants());
 
     expect(result.current).toEqual([
-      {user_id: 'some-spotlight-user-id', owner: true},
-      {user_id: 'some-other-user-id', owner: false},
+      {session_id: 'some-spotlight-session-id', owner: true},
+      {session_id: 'some-other-session-id', owner: false},
     ]);
   });
 
   it('filter participants who are in the portal', () => {
     useDailyState.setState({
       participants: {
-        ...createParticipant('some-in-portal-user-id', {inPortal: true}),
-        ...createParticipant('some-not-in-portal-user-id', {inPortal: false}),
-        ...createParticipant('some-without-user-data-user-id'),
+        ...createParticipant('some-in-portal-session-id', {inPortal: true}),
+        ...createParticipant('some-not-in-portal-session-id', {
+          inPortal: false,
+        }),
+        ...createParticipant('some-without-user-data-session-id'),
       },
     });
 
@@ -109,11 +111,11 @@ describe('useSessionParticipants', () => {
 
     expect(result.current).toEqual([
       {
-        user_id: 'some-not-in-portal-user-id',
+        session_id: 'some-not-in-portal-session-id',
         userData: {inPortal: false},
         owner: false,
       },
-      {user_id: 'some-without-user-data-user-id', owner: false},
+      {session_id: 'some-without-user-data-session-id', owner: false},
     ]);
   });
 });

--- a/client/src/lib/session/hooks/useSessionParticipants.ts
+++ b/client/src/lib/session/hooks/useSessionParticipants.ts
@@ -20,7 +20,8 @@ const useSessionParticipants = () => {
     ];
 
     const inSessionParticipants = participants.filter(
-      participant => !(participant.userData as DailyUserData)?.inPortal,
+      participant =>
+        participant && !(participant.userData as DailyUserData)?.inPortal,
     );
 
     if (isHostSlide) {


### PR DESCRIPTION
This was caused by keying on `user_id`. Users who dropped out and rejoined was joining with the same id since we now have tokens. Since we store participants keyed on `user_id` and there came and update event about the lingering user from before the drop where the local flag was false and then the user was not recognised as owner i.e host anymore since the update overwrote the local participants created before the update event. Also made any user who rejoined disappear after a while
