### PR TITLE
Fetch lottie to remove auto play bug

### DIFF
--- a/client/src/lib/components/LottiePlayer/LottiePlayer.tsx
+++ b/client/src/lib/components/LottiePlayer/LottiePlayer.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import AnimatedLottieView, {AnimatedLottieViewProps} from 'lottie-react-native';
 import {View, ViewStyle} from 'react-native';
+import useFetchLottie from './hooks/useFetchLottie';
 
 export type LottiePlayerProps = {
   style?: ViewStyle;
@@ -26,6 +27,7 @@ export type LottiePlayerHandle = {
 const LottiePlayer = forwardRef<LottiePlayerHandle, LottiePlayerProps>(
   ({style, source, paused, onEnd, duration = 60, repeat = false}, ref) => {
     const lottieRef = useRef<AnimatedLottieView>(null);
+    const lottieSource = useFetchLottie(source);
     const [progress, setProgress] = useState(0);
 
     const togglePaused = useCallback((pause: boolean) => {
@@ -66,11 +68,15 @@ const LottiePlayer = forwardRef<LottiePlayerHandle, LottiePlayerProps>(
       togglePaused(paused);
     }, [paused, togglePaused]);
 
+    if (!lottieSource) {
+      return null;
+    }
+
     return (
       <View style={style}>
         <AnimatedLottieView
           onAnimationFinish={onAnimationFinish}
-          source={source}
+          source={lottieSource}
           speed={duration ? 60 / duration : 1}
           loop={repeat}
           autoPlay={!paused}

--- a/client/src/lib/components/LottiePlayer/hooks/useFetchLottie.ts
+++ b/client/src/lib/components/LottiePlayer/hooks/useFetchLottie.ts
@@ -1,0 +1,36 @@
+import {AnimatedLottieViewProps, AnimationObject} from 'lottie-react-native';
+import {useEffect, useState} from 'react';
+
+function instanceOfAnimationObject(object: any): object is AnimationObject {
+  return 'v' in object;
+}
+
+const useFetchLottie = (source: AnimatedLottieViewProps['source']) => {
+  const [content, setContent] = useState<
+    AnimatedLottieViewProps['source'] | null
+  >(null);
+
+  useEffect(() => {
+    const fetchContent = async () => {
+      if (typeof source !== 'string' && !instanceOfAnimationObject(source)) {
+        try {
+          const res = await fetch(source.uri);
+          setContent(await res.json());
+        } catch (err) {
+          console.error(
+            new Error(`Unable to fetch lottie file ${source.uri}`, {
+              cause: err,
+            }),
+          );
+        }
+      } else {
+        setContent(source);
+      }
+    };
+    fetchContent();
+  }, [source]);
+
+  return content;
+};
+
+export default useFetchLottie;

--- a/client/src/lib/components/LottiePlayer/hooks/useFetchLottie.ts
+++ b/client/src/lib/components/LottiePlayer/hooks/useFetchLottie.ts
@@ -5,6 +5,11 @@ function instanceOfAnimationObject(object: any): object is AnimationObject {
   return 'v' in object;
 }
 
+// This exists since there are several bugs when supplying source as
+// {uri: 'https://some.json'}
+// * The animation starts playing directly even when autoPlay is false
+// * onAnimationFinnish do not fire
+// Issue reported here https://github.com/lottie-react-native/lottie-react-native/issues/968
 const useFetchLottie = (source: AnimatedLottieViewProps['source']) => {
   const [content, setContent] = useState<
     AnimatedLottieViewProps['source'] | null


### PR DESCRIPTION
Since supplying lottie with `{uri: 'http://path-to-file.json'}` causes autoplay and does not fire `onAnimationFinish` this is our old solution from the existing app. Issue reported to lottie-react-native here https://github.com/lottie-react-native/lottie-react-native/issues/968
