### PR TITLE
Async sharing adjustments

### DIFF
--- a/client/src/lib/posts/hooks/useSharingPosts.ts
+++ b/client/src/lib/posts/hooks/useSharingPosts.ts
@@ -66,7 +66,7 @@ const useSharingPosts = (exerciseId?: string) => {
         )
         .sort(
           (a, b) =>
-            new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+            new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
         );
     },
     [postEvents, exerciseId],

--- a/client/src/lib/session/components/Slides/Slide.tsx
+++ b/client/src/lib/session/components/Slides/Slide.tsx
@@ -60,7 +60,7 @@ const Slide = ({slide, active, async}: SlideProps) => {
       )}
       {slide.type === 'sharing' &&
         (async ? (
-          <Sharing slide={slide} active={active} />
+          <Sharing slide={slide} />
         ) : (
           <Content async={async} slide={slide} active={active} />
         ))}

--- a/client/src/lib/session/components/Slides/Slides/Sharing.tsx
+++ b/client/src/lib/session/components/Slides/Slides/Sharing.tsx
@@ -94,10 +94,9 @@ const EmptyListComponent = styled.View({
 
 type SharingProps = {
   slide: ExerciseSlideSharingSlide;
-  active: boolean;
 };
 
-const Sharing: React.FC<SharingProps> = ({slide, active}) => {
+const Sharing: React.FC<SharingProps> = ({slide}) => {
   const scrollRef = useRef<ScrollView>(null);
   const {t} = useTranslation('Component.Sharing');
   const {navigate} =
@@ -127,10 +126,8 @@ const Sharing: React.FC<SharingProps> = ({slide, active}) => {
   const [posts, setPosts] = useState<Post[]>([]);
 
   useEffect(() => {
-    if (active) {
-      getSharingPosts().then(setPosts);
-    }
-  }, [getSharingPosts, active]);
+    getSharingPosts().then(setPosts);
+  }, [getSharingPosts]);
 
   const onAddSharing = useCallback(() => {
     if (session?.exerciseId) {
@@ -175,16 +172,13 @@ const Sharing: React.FC<SharingProps> = ({slide, active}) => {
   );
 
   useEffect(() => {
-    if (active) {
-      // Wait until oters posts has rendered
-      requestAnimationFrame(() => {
-        scrollRef.current?.scrollTo({
-          y: otherPostListHeight + myPostListHeight,
-          animated: true,
-        });
+    requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({
+        y: otherPostListHeight + myPostListHeight,
+        animated: true,
       });
-    }
-  }, [otherPostListHeight, myPostListHeight, active]);
+    });
+  }, [otherPostListHeight, myPostListHeight]);
 
   const userProfile = useMemo(() => {
     if (user?.displayName) {

--- a/client/src/routes/modals/CompletedSessionModal/CompletedSessionModal.tsx
+++ b/client/src/routes/modals/CompletedSessionModal/CompletedSessionModal.tsx
@@ -79,7 +79,7 @@ const CompletedSessionModal = () => {
   const {
     params: {completedSessionEvent, hostProfile},
   } = useRoute<RouteProp<ModalStackProps, 'CompletedSessionModal'>>();
-  const {navigate} =
+  const {navigate, popToTop} =
     useNavigation<NativeStackNavigationProp<ModalStackProps>>();
   const {t} = useTranslation('Modal.CompletedSession');
   const {payload, timestamp} = completedSessionEvent;
@@ -88,8 +88,9 @@ const CompletedSessionModal = () => {
   const sessionTime = useMemo(() => dayjs(timestamp), [timestamp]);
 
   const onStartSession = useCallback(() => {
+    popToTop();
     navigate('CreateSessionModal', {exerciseId: payload.exerciseId});
-  }, [payload, navigate]);
+  }, [payload, navigate, popToTop]);
 
   const exercise = useExerciseById(payload.exerciseId);
   const {getSharingPostForSession} = useSharingPosts(exercise?.id);


### PR DESCRIPTION
- [x] Load posts while on previous slide to make it done by the time you arrive there
- [x] Scroll to add sharing button while on previous slide
- [x] Sort your prev sharings as latest first
- [x] Close `CompletedSessionModal` when pressing "Do this exercise again" to not get back to it when `CreateSessionModal` is closed
