### PR TITLE
Implement closingTime logic for sessions

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -5,6 +5,28 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "userIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "ended",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "closingTime",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "startTime",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "ended",
           "order": "ASCENDING"
         },

--- a/functions/scripts/migrateClosingTime.ts
+++ b/functions/scripts/migrateClosingTime.ts
@@ -1,0 +1,42 @@
+import admin from 'firebase-admin';
+import {Timestamp} from 'firebase-admin/firestore';
+import dayjs from 'dayjs';
+
+const {GOOGLE_APPLICATION_CREDENTIALS} = process.env;
+
+if (!GOOGLE_APPLICATION_CREDENTIALS) {
+  console.error(
+    'GOOGLE_APPLICATION_CREDENTIALS env pointing to service-account.json is required',
+  );
+  process.exit(1);
+}
+
+admin.initializeApp();
+const firestore = admin.firestore();
+
+(async () => {
+  const sessionsCollection = firestore.collection('sessions');
+  const snapshot = await sessionsCollection.where('ended', '==', false).get();
+
+  await Promise.all(
+    snapshot.docs.map(async doc => {
+      const {id, startTime} = doc.data();
+
+      firestore
+        .collection('sessions')
+        .doc(id)
+        .set(
+          {
+            closingTime: Timestamp.fromDate(
+              dayjs(startTime.toDate()).add(30, 'minutes').toDate(),
+            ),
+          },
+          {merge: true},
+        );
+    }),
+  );
+
+  console.log(
+    `${snapshot.docs.length} session docs updated with closingTime (startTime + 5min).`,
+  );
+})();

--- a/functions/scripts/migrateClosingTime.ts
+++ b/functions/scripts/migrateClosingTime.ts
@@ -37,6 +37,6 @@ const firestore = admin.firestore();
   );
 
   console.log(
-    `${snapshot.docs.length} session docs updated with closingTime (startTime + 5min).`,
+    `${snapshot.docs.length} session docs updated with closingTime (startTime + 30 min).`,
   );
 })();

--- a/functions/src/controllers/sessions.spec.ts
+++ b/functions/src/controllers/sessions.spec.ts
@@ -588,6 +588,28 @@ describe('sessions - controller', () => {
       expect(updatedState).toEqual({id: 'some-session-id', index: 1});
     });
 
+    it('should update the session closingTime when started', async () => {
+      mockGetSessionStateById.mockResolvedValueOnce({
+        id: 'some-session-id',
+        started: true,
+      }); // first return (to check if it exists)
+      mockGetSessionStateById.mockResolvedValueOnce({
+        id: 'some-session-id',
+        started: true,
+      }); // returned value
+
+      const updatedState = await updateSessionState(
+        'the-host-id',
+        'some-session-id',
+        {started: true},
+      );
+
+      expect(mockUpdateSession).toHaveBeenCalledWith('some-session-id', {
+        closingTime: '2022-10-10T09:05:00.000Z',
+      });
+      expect(updatedState).toEqual({id: 'some-session-id', started: true});
+    });
+
     it('should also update the session when is ended', async () => {
       mockGetSessionById.mockResolvedValueOnce({
         id: 'some-session-id',

--- a/functions/src/controllers/sessions.ts
+++ b/functions/src/controllers/sessions.ts
@@ -206,6 +206,12 @@ export const updateSessionState = async (
     sessionModel.updateSession(sessionId, {ended: true});
   }
 
+  if (data.started) {
+    sessionModel.updateSession(sessionId, {
+      closingTime: dayjs().add(5, 'minutes').toString(),
+    });
+  }
+
   await sessionModel.updateSessionState(sessionId, removeEmpty(data));
   const updatedState = await sessionModel.getSessionStateById(sessionId);
   return updatedState ? updatedState : undefined;

--- a/functions/src/controllers/sessions.ts
+++ b/functions/src/controllers/sessions.ts
@@ -208,7 +208,7 @@ export const updateSessionState = async (
 
   if (data.started) {
     sessionModel.updateSession(sessionId, {
-      closingTime: dayjs().add(5, 'minutes').toString(),
+      closingTime: dayjs().add(5, 'minutes').toISOString(),
     });
   }
 

--- a/functions/src/models/session.spec.ts
+++ b/functions/src/models/session.spec.ts
@@ -47,6 +47,7 @@ const sessions = [
     startTime: Timestamp.now(),
     userIds: ['*'],
     interestedCount: 0,
+    closingTime: Timestamp.now(),
     createdAt: Timestamp.now(),
     updatedAt: Timestamp.now(),
     _collections: {
@@ -72,6 +73,7 @@ const sessions = [
     type: SessionType.public,
     userIds: ['*'],
     interestedCount: 1,
+    closingTime: Timestamp.now(),
     createdAt: Timestamp.now(),
     updatedAt: Timestamp.now(),
     _collections: {
@@ -118,6 +120,7 @@ describe('session model', () => {
         name: 'some-name',
         exerciseId: 'some-exercise-id',
         startTime: expect.any(String),
+        closingTime: expect.any(String),
         url: 'some-url',
         type: 'public',
         userIds: ['*'],
@@ -139,7 +142,7 @@ describe('session model', () => {
       expect(mockWhere).toHaveBeenCalledWith('inviteCode', '==', 12345);
       expect(mockWhere).toHaveBeenCalledWith('ended', '==', false);
       expect(mockWhere).toHaveBeenCalledWith(
-        'startTime',
+        'closingTime',
         '>',
         expect.any(Timestamp),
       );
@@ -156,6 +159,7 @@ describe('session model', () => {
           name: 'some-name',
           exerciseId: 'some-exercise-id',
           startTime: expect.any(String),
+          closingTime: expect.any(String),
           url: 'some-url',
           type: 'public',
           userIds: ['*'],
@@ -169,6 +173,7 @@ describe('session model', () => {
           name: 'some-other-name',
           exerciseId: 'some-exercise-id',
           startTime: expect.any(String),
+          closingTime: expect.any(String),
           url: 'some-other-url',
           type: 'public',
           userIds: ['*'],
@@ -183,7 +188,7 @@ describe('session model', () => {
       await getSessions('some-user-id');
       expect(mockWhere).toHaveBeenCalledWith('ended', '==', false);
       expect(mockWhere).toHaveBeenCalledWith(
-        'startTime',
+        'closingTime',
         '>',
         expect.any(Timestamp),
       );
@@ -216,6 +221,7 @@ describe('session model', () => {
           name: 'some-name',
           exerciseId: 'some-exercise-id',
           startTime: expect.any(String),
+          closingTime: expect.any(String),
           url: 'some-url',
           type: 'public',
           userIds: ['*'],
@@ -229,6 +235,7 @@ describe('session model', () => {
           name: 'some-other-name',
           exerciseId: 'some-exercise-id',
           startTime: expect.any(String),
+          closingTime: expect.any(String),
           url: 'some-other-url',
           type: 'public',
           userIds: ['*'],
@@ -243,7 +250,7 @@ describe('session model', () => {
       await getPublicSessionsByExerciseId('some-user-id', 'some-exercise-id');
       expect(mockWhere).toHaveBeenCalledWith('ended', '==', false);
       expect(mockWhere).toHaveBeenCalledWith(
-        'startTime',
+        'closingTime',
         '>',
         expect.any(Timestamp),
       );
@@ -265,7 +272,8 @@ describe('session model', () => {
   });
 
   describe('addSession', () => {
-    const startTime = new Date('1994-03-08T07:24:00').toISOString();
+    const startTime = new Date('1994-03-08T07:30:00').toISOString();
+    const closingTime = new Date('1994-03-08T08:00:00').toISOString();
 
     it('should return public session', async () => {
       const session = await addSession({
@@ -289,7 +297,8 @@ describe('session model', () => {
         hostId: 'some-user-id',
         id: 'session-id',
         link: 'deep-link',
-        startTime: startTime,
+        startTime,
+        closingTime,
         type: 'public',
         mode: 'live',
         url: 'daily-url',
@@ -311,7 +320,7 @@ describe('session model', () => {
         exerciseId: 'content-id',
         link: 'deep-link',
         type: SessionType.private,
-        startTime: startTime,
+        startTime,
         hostId: 'some-user-id',
         inviteCode: 1234,
         interestedCount: 0,
@@ -324,7 +333,7 @@ describe('session model', () => {
         hostId: 'some-user-id',
         id: 'session-id',
         link: 'deep-link',
-        startTime: startTime,
+        startTime,
         type: 'private',
         mode: 'live',
         url: 'daily-url',
@@ -332,6 +341,7 @@ describe('session model', () => {
         ended: false,
         inviteCode: 1234,
         interestedCount: 0,
+        closingTime,
         createdAt: expect.any(String),
         updatedAt: expect.any(String),
       });
@@ -351,6 +361,7 @@ describe('session model', () => {
         exerciseId: 'some-exercise-id',
         interestedCount: 0,
         startTime: expect.any(String),
+        closingTime: expect.any(String),
         type: SessionType.private,
         userIds: ['*'],
         createdAt: expect.any(String),
@@ -372,6 +383,7 @@ describe('session model', () => {
         type: 'public',
         interestedCount: 0,
         startTime: expect.any(String),
+        closingTime: expect.any(String),
         userIds: ['*'],
         createdAt: expect.any(String),
         updatedAt: expect.any(String),

--- a/functions/src/models/session.ts
+++ b/functions/src/models/session.ts
@@ -71,13 +71,7 @@ export const getSessionByInviteCode = async ({
   const result = await (activeOnly
     ? query
         .where('ended', '==', false)
-        .where(
-          'startTime',
-          '>',
-          Timestamp.fromDate(
-            dayjs(Timestamp.now().toDate()).subtract(30, 'minute').toDate(),
-          ),
-        )
+        .where('closingTime', '>', Timestamp.now())
     : query
   )
     .orderBy('startTime', 'asc')
@@ -94,13 +88,7 @@ export const getSessions = async (userId: string) => {
   const sessionsCollection = firestore().collection(SESSIONS_COLLECTION);
   const snapshot = await sessionsCollection
     .where('ended', '==', false)
-    .where(
-      'startTime',
-      '>',
-      Timestamp.fromDate(
-        dayjs(Timestamp.now().toDate()).subtract(30, 'minute').toDate(),
-      ),
-    )
+    .where('closingTime', '>', Timestamp.now())
     .where('userIds', 'array-contains-any', ['*', userId])
     .orderBy('startTime', 'asc')
     .get();
@@ -115,13 +103,7 @@ export const getPublicSessionsByExerciseId = async (
   const sessionsCollection = firestore().collection(SESSIONS_COLLECTION);
   const snapshot = await sessionsCollection
     .where('ended', '==', false)
-    .where(
-      'startTime',
-      '>',
-      Timestamp.fromDate(
-        dayjs(Timestamp.now().toDate()).subtract(30, 'minute').toDate(),
-      ),
-    )
+    .where('closingTime', '>', Timestamp.now())
     .where('exerciseId', '==', exerciseId)
     .where('userIds', 'array-contains-any', ['*', userId])
     .orderBy('startTime', 'asc')
@@ -144,7 +126,7 @@ export const addSession = async ({
   interestedCount,
 }: Omit<
   LiveSession,
-  'mode' | 'ended' | 'userIds' | 'createdAt' | 'updatedAt'
+  'mode' | 'ended' | 'userIds' | 'createdAt' | 'updatedAt' | 'closingTime'
 > & {
   dailyRoomName: string;
 }) => {
@@ -167,6 +149,9 @@ export const addSession = async ({
     ended: false,
     // '*' means session is available for everyone/public enables one single query on getSessions
     userIds: type === SessionType.private ? [hostId] : ['*'],
+    closingTime: Timestamp.fromDate(
+      dayjs(startTime).add(30, 'minutes').toDate(),
+    ),
   };
 
   const sessionDoc = firestore().collection(SESSIONS_COLLECTION).doc(id);
@@ -193,6 +178,9 @@ export const updateSession = async (
     ...data,
     ...(data.startTime
       ? {startTime: Timestamp.fromDate(new Date(data.startTime))}
+      : {}),
+    ...(data.closingTime
+      ? {closingTime: Timestamp.fromDate(new Date(data.closingTime))}
       : {}),
   };
 

--- a/functions/src/models/session.ts
+++ b/functions/src/models/session.ts
@@ -71,6 +71,7 @@ export const getSessionByInviteCode = async ({
   const result = await (activeOnly
     ? query
         .where('ended', '==', false)
+        .orderBy('closingTime')
         .where('closingTime', '>', Timestamp.now())
     : query
   )
@@ -88,8 +89,9 @@ export const getSessions = async (userId: string) => {
   const sessionsCollection = firestore().collection(SESSIONS_COLLECTION);
   const snapshot = await sessionsCollection
     .where('ended', '==', false)
-    .where('closingTime', '>', Timestamp.now())
     .where('userIds', 'array-contains-any', ['*', userId])
+    .orderBy('closingTime')
+    .where('closingTime', '>', Timestamp.now())
     .orderBy('startTime', 'asc')
     .get();
 
@@ -103,9 +105,10 @@ export const getPublicSessionsByExerciseId = async (
   const sessionsCollection = firestore().collection(SESSIONS_COLLECTION);
   const snapshot = await sessionsCollection
     .where('ended', '==', false)
-    .where('closingTime', '>', Timestamp.now())
     .where('exerciseId', '==', exerciseId)
     .where('userIds', 'array-contains-any', ['*', userId])
+    .orderBy('closingTime')
+    .where('closingTime', '>', Timestamp.now())
     .orderBy('startTime', 'asc')
     .get();
 

--- a/shared/src/modelUtils/session.ts
+++ b/shared/src/modelUtils/session.ts
@@ -8,6 +8,7 @@ import {
 export const getSession = (session: LiveSessionData): LiveSession => ({
   ...session,
   startTime: session.startTime.toDate().toISOString(),
+  closingTime: session.closingTime.toDate().toISOString(),
   createdAt: session.createdAt.toDate().toISOString(),
   updatedAt: session.updatedAt.toDate().toISOString(),
 });

--- a/shared/src/types/Session.ts
+++ b/shared/src/types/Session.ts
@@ -46,6 +46,7 @@ export type SessionStateData = SessionStateFields & {
 };
 
 export type LiveSessionData = LiveSessionFields & {
+  closingTime: Timestamp;
   startTime: Timestamp;
   createdAt: Timestamp;
   updatedAt: Timestamp;
@@ -57,6 +58,7 @@ export type SessionState = SessionStateFields & {
 };
 
 export type LiveSession = LiveSessionFields & {
+  closingTime: string;
   startTime: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
Related to [this notion task](https://www.notion.so/29k/Early-Access-2794500652b34c64b0aff0dbbc53e0ab?pvs=4#1228dd30e0614599886bed243445127f)

### Description of the Change

This will simplify the filtering for `closed` sessions altogether, 
if we don't do this we would need to make 2 queries.


https://github.com/29ki/29k/blob/87c78584f59de2ed04cdff62d46a14a68ed3308d/functions/src/models/session.ts#L87-L97


If we would try to filter through a separate field we'd need to define it a default value as far ahead of time so sessions that didn't start wouldn't be filtered out, or do two queries: started sessions, not started sessions and combine, so why not refactor the way we filter for `startTime` + 30min and do it with one field only, `closingTime`.

Let me know your thoughts!