### PR TITLE
Change default async session type

### DIFF
--- a/client/src/lib/session/hooks/useStartAsyncSession.ts
+++ b/client/src/lib/session/hooks/useStartAsyncSession.ts
@@ -30,7 +30,7 @@ const useStartAsyncSession = () => {
   return useCallback(
     (exerciseId: string) => {
       const session: AsyncSession = {
-        type: SessionType.private,
+        type: SessionType.public,
         mode: SessionMode.async,
         id: generateId(),
         startTime: dayjs().toJSON(),

--- a/client/src/lib/user/state/migration/index.spec.ts
+++ b/client/src/lib/user/state/migration/index.spec.ts
@@ -3,11 +3,13 @@ import v0 from './v0';
 import v1 from './v1';
 import v2 from './v2';
 import v3 from './v3';
+import v4 from './v4';
 
 jest.mock('./v0', () => jest.fn((state: unknown) => state));
 jest.mock('./v1', () => jest.fn((state: unknown) => state));
 jest.mock('./v2', () => jest.fn((state: unknown) => state));
 jest.mock('./v3', () => jest.fn((state: unknown) => state));
+jest.mock('./v4', () => jest.fn((state: unknown) => state));
 
 afterEach(jest.clearAllMocks);
 
@@ -27,6 +29,8 @@ describe('migrate', () => {
       expect(v2).toHaveBeenCalledWith(persistedState);
       expect(v3).toHaveBeenCalledTimes(1);
       expect(v3).toHaveBeenCalledWith(persistedState);
+      expect(v4).toHaveBeenCalledTimes(1);
+      expect(v4).toHaveBeenCalledWith(persistedState);
     });
   });
 
@@ -40,6 +44,8 @@ describe('migrate', () => {
       expect(v2).toHaveBeenCalledWith(persistedState);
       expect(v3).toHaveBeenCalledTimes(1);
       expect(v3).toHaveBeenCalledWith(persistedState);
+      expect(v4).toHaveBeenCalledTimes(1);
+      expect(v4).toHaveBeenCalledWith(persistedState);
     });
   });
 
@@ -52,6 +58,8 @@ describe('migrate', () => {
       expect(v2).toHaveBeenCalledWith(persistedState);
       expect(v3).toHaveBeenCalledTimes(1);
       expect(v3).toHaveBeenCalledWith(persistedState);
+      expect(v4).toHaveBeenCalledTimes(1);
+      expect(v4).toHaveBeenCalledWith(persistedState);
     });
   });
 
@@ -63,6 +71,20 @@ describe('migrate', () => {
       expect(v2).toHaveBeenCalledTimes(0);
       expect(v3).toHaveBeenCalledTimes(1);
       expect(v3).toHaveBeenCalledWith(persistedState);
+      expect(v4).toHaveBeenCalledTimes(1);
+      expect(v4).toHaveBeenCalledWith(persistedState);
+    });
+  });
+
+  describe('version 4', () => {
+    it('migrates from 4 upwards', async () => {
+      await migrate(persistedState, 4);
+      expect(v0).toHaveBeenCalledTimes(0);
+      expect(v1).toHaveBeenCalledTimes(0);
+      expect(v2).toHaveBeenCalledTimes(0);
+      expect(v3).toHaveBeenCalledTimes(0);
+      expect(v4).toHaveBeenCalledTimes(1);
+      expect(v4).toHaveBeenCalledWith(persistedState);
     });
   });
 });

--- a/client/src/lib/user/state/migration/index.ts
+++ b/client/src/lib/user/state/migration/index.ts
@@ -5,6 +5,7 @@ import migrateV0, {V0State} from './v0';
 import migrateV1, {V1State} from './v1';
 import migrateV2, {V2State} from './v2';
 import migrateV3, {V3State} from './v3';
+import migrateV4, {V4State} from './v4';
 
 const migrate: Required<
   PersistOptions<State & Actions, PersistedState>
@@ -25,6 +26,10 @@ const migrate: Required<
 
   if (version <= 3) {
     state = await migrateV3(state as V3State);
+  }
+
+  if (version <= 4) {
+    state = await migrateV4(state as V4State);
   }
 
   return state as State & Actions;

--- a/client/src/lib/user/state/migration/v3.ts
+++ b/client/src/lib/user/state/migration/v3.ts
@@ -4,11 +4,7 @@ import {
   UserEvent as CurrentUserEvent,
 } from '../../../../../../shared/src/types/Event';
 import {LANGUAGE_TAG} from '../../../i18n';
-import {
-  PersistedState,
-  State as CurrentState,
-  UserState as CurrentUserState,
-} from '../state';
+import {V4State, V4UserState} from './v4';
 
 // Types as they were in v3
 type V3PinnedSession = {
@@ -94,9 +90,9 @@ const migrateCompletedSessionsToEvents = (
 
 const migrateUserState = async (
   userState: V3UserState,
-): Promise<CurrentUserState> => {
+): Promise<V4UserState> => {
   if (!userState.completedSessions) {
-    return userState as CurrentUserState;
+    return userState as V4UserState;
   }
 
   return {
@@ -106,15 +102,15 @@ const migrateUserState = async (
       ...migrateCompletedSessionsToEvents(userState.completedSessions),
     ],
     completedSessions: undefined,
-  } as CurrentUserState;
+  } as V4UserState;
 };
 
 const migrateUserStates = async (
   userStates: V3State['userState'],
-): Promise<CurrentState['userState']> => {
+): Promise<V4State['userState']> => {
   const userState = await Promise.all(
     Object.entries(userStates).map(
-      async ([userId, state]): Promise<[string, CurrentUserState]> => [
+      async ([userId, state]): Promise<[string, V4UserState]> => [
         userId,
         await migrateUserState(state),
       ],
@@ -130,7 +126,7 @@ const migrateUserStates = async (
   );
 };
 
-export default async (state: V3State): Promise<PersistedState> => ({
+export default async (state: V3State): Promise<V4State> => ({
   ...state,
   userState: await migrateUserStates(state.userState),
 });

--- a/client/src/lib/user/state/migration/v4.spec.ts
+++ b/client/src/lib/user/state/migration/v4.spec.ts
@@ -1,0 +1,160 @@
+import {
+  CompletedSessionPayload,
+  FeedbackPayload,
+} from '../../../../../../shared/src/types/Event';
+import {
+  SessionMode,
+  SessionType,
+} from '../../../../../../shared/src/types/Session';
+import v4, {V4State, V4UserState} from './v4';
+
+jest.mock('../../../sessions/api/session');
+
+afterEach(jest.clearAllMocks);
+
+describe('v4', () => {
+  it('should return state as is if completed sessions is not present', async () => {
+    const state = {
+      someOtherState: 'foo',
+      userState: {
+        'some-uid': {someProp: 'test'},
+      },
+    } as V4State;
+
+    const unchangedState = await v4(state);
+
+    expect(unchangedState).toEqual(state);
+  });
+
+  it('should migrate session mode to public for all async sessions', async () => {
+    const state = {
+      someOtherState: 'foo',
+      userState: {
+        'some-uid': {
+          pinnedSessions: [{id: 'some-session', expires: new Date()}],
+          userEvents: [
+            {
+              type: 'completedSession',
+              payload: {
+                id: 'migrated-session-id',
+                mode: SessionMode.async,
+                type: SessionType.private,
+              } as CompletedSessionPayload,
+              timestamp: new Date().toISOString(),
+            },
+            {
+              type: 'completedSession',
+              payload: {
+                id: 'not-migrated-session-id-1',
+                mode: SessionMode.async,
+                type: SessionType.public,
+              } as CompletedSessionPayload,
+              timestamp: new Date().toISOString(),
+            },
+            {
+              type: 'completedSession',
+              payload: {
+                id: 'not-migrated-session-id-2',
+                mode: SessionMode.live,
+                type: SessionType.private,
+              } as CompletedSessionPayload,
+              timestamp: new Date().toISOString(),
+            },
+            {
+              type: 'completedSession',
+              payload: {
+                id: 'not-migrated-session-id-3',
+                mode: SessionMode.live,
+                type: SessionType.public,
+              } as CompletedSessionPayload,
+              timestamp: new Date().toISOString(),
+            },
+            {
+              type: 'feedback',
+              payload: {
+                sessionId: 'some-session-id',
+              } as FeedbackPayload,
+              timestamp: new Date().toISOString(),
+            },
+          ],
+        } as V4UserState,
+      },
+    };
+
+    const newState = await v4(state);
+    expect(newState).toEqual({
+      someOtherState: 'foo',
+      userState: {
+        'some-uid': {
+          pinnedSessions: [{id: 'some-session', expires: expect.any(Date)}],
+          userEvents: [
+            {
+              type: 'completedSession',
+              payload: {
+                id: 'migrated-session-id',
+                mode: SessionMode.async,
+                type: SessionType.public,
+              },
+              timestamp: expect.any(String),
+            },
+            {
+              type: 'completedSession',
+              payload: {
+                id: 'not-migrated-session-id-1',
+                mode: SessionMode.async,
+                type: SessionType.public,
+              },
+              timestamp: expect.any(String),
+            },
+            {
+              type: 'completedSession',
+              payload: {
+                id: 'not-migrated-session-id-2',
+                mode: SessionMode.live,
+                type: SessionType.private,
+              },
+              timestamp: expect.any(String),
+            },
+            {
+              type: 'completedSession',
+              payload: {
+                id: 'not-migrated-session-id-3',
+                mode: SessionMode.live,
+                type: SessionType.public,
+              },
+              timestamp: expect.any(String),
+            },
+            {
+              type: 'feedback',
+              payload: {
+                sessionId: 'some-session-id',
+              },
+              timestamp: expect.any(String),
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('should not migrate anything if userEvents is undefined', async () => {
+    const state = {
+      someOtherState: 'foo',
+      userState: {
+        'some-uid': {
+          pinnedSessions: [{id: 'some-session', expires: new Date()}],
+        } as V4UserState,
+      },
+    };
+
+    const newState = await v4(state);
+    expect(newState).toEqual({
+      someOtherState: 'foo',
+      userState: {
+        'some-uid': {
+          pinnedSessions: [{id: 'some-session', expires: expect.any(Date)}],
+        },
+      },
+    });
+  });
+});

--- a/client/src/lib/user/state/migration/v4.ts
+++ b/client/src/lib/user/state/migration/v4.ts
@@ -1,0 +1,72 @@
+import {UserEvent} from '../../../../../../shared/src/types/Event';
+import {
+  SessionMode,
+  SessionType,
+} from '../../../../../../shared/src/types/Session';
+import {
+  PersistedState,
+  State as CurrentState,
+  UserState as CurrentUserState,
+} from '../state';
+
+// Types as they were in v4
+type PinnedSession = {
+  id: string;
+  expires: Date;
+};
+
+export type V4UserState = {
+  pinnedSessions?: Array<PinnedSession>;
+  userEvents?: Array<UserEvent>;
+  metricsUid?: string;
+  reminderNotifications?: boolean;
+};
+
+export type V4State = {
+  userState: {[key: string]: V4UserState};
+};
+const migrateUserState = async (
+  userState: V4UserState,
+): Promise<CurrentUserState> => ({
+  ...userState,
+  userEvents: userState.userEvents?.map(event =>
+    event.type === 'completedSession'
+      ? {
+          ...event,
+          payload: {
+            ...event.payload,
+            type:
+              event.payload.mode === SessionMode.async
+                ? SessionType.public
+                : event.payload.type,
+          },
+        }
+      : event,
+  ),
+});
+
+const migrateUserStates = async (
+  userStates: V4State['userState'],
+): Promise<CurrentState['userState']> => {
+  const userState = await Promise.all(
+    Object.entries(userStates).map(
+      async ([userId, state]): Promise<[string, CurrentUserState]> => [
+        userId,
+        await migrateUserState(state),
+      ],
+    ),
+  );
+
+  return userState.reduce(
+    (states, [userId, state]) => ({
+      ...states,
+      [userId]: state,
+    }),
+    {},
+  );
+};
+
+export default async (state: V4State): Promise<PersistedState> => ({
+  ...state,
+  userState: await migrateUserStates(state.userState),
+});

--- a/client/src/lib/user/state/state.ts
+++ b/client/src/lib/user/state/state.ts
@@ -17,7 +17,7 @@ import {
 
 dayjs.extend(utc);
 
-const USER_STATE_VERSION = 4;
+const USER_STATE_VERSION = 5;
 
 type PinnedSession = {
   id: string;


### PR DESCRIPTION
I managed to flag all async sessions as `private` when they are in fact `public`. This flags them appropriately and migrates all `completedSession` events.