### PR TITLE
Track event Origin

### DIFF
--- a/client/__mocks__/@react-native-firebase/app.js
+++ b/client/__mocks__/@react-native-firebase/app.js
@@ -1,0 +1,3 @@
+const mockApp = jest.fn();
+
+export default mockApp;

--- a/client/__mocks__/@react-native-firebase/dynamic-links.js
+++ b/client/__mocks__/@react-native-firebase/dynamic-links.js
@@ -1,0 +1,3 @@
+const mockDynamicLinks = jest.fn();
+
+export default mockDynamicLinks;

--- a/client/__mocks__/@react-navigation/native.js
+++ b/client/__mocks__/@react-navigation/native.js
@@ -2,5 +2,11 @@ const mockNavigation = {
   navigate: jest.fn(),
 };
 
+export const DefaultTheme = {
+  colors: '#00000',
+};
+
+export const createNavigationContainerRef = jest.fn();
+
 export const useNavigation = jest.fn(() => mockNavigation);
 export const useIsFocused = jest.fn();

--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -10,6 +10,8 @@ process.env = Object.assign(process.env, {
   STORAGE_ENDPOINT: 'some-storage-endpoint',
   GIT_COMMIT_SHORT: 'some-git-hash',
   SENTRY_DSN: 'some-sentry-dsn',
+  DEEP_LINK_SCHEMA: 'some-deep-link-schema',
+  DEEP_LINK_PREFIX: 'some-deep-link-prefix',
 });
 const modules = ['react-native', '@react-native', '@notifee'];
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,7 @@
 import React, {Suspense} from 'react';
 
 import Navigation from './lib/navigation/Navigation';
-import ModalStack from './lib/navigation/ModalStack';
+import {MetricsProvider} from './lib/metrics';
 
 import codePush, {CodePushOverlay} from './lib/codePush';
 import {UiLibProvider} from './lib/uiLib/hooks/useUiLib';
@@ -14,7 +14,7 @@ import styled from 'styled-components/native';
 const GestureHandler = styled(GestureHandlerRootView)({
   flex: 1,
 });
-import {MetricsProvider} from './lib/metrics';
+import RootNavigator from './lib/navigation/RootNavigator';
 
 const App = () => (
   <ErrorBoundary>
@@ -25,7 +25,7 @@ const App = () => (
             <MetricsProvider>
               <Bootstrap>
                 <Suspense>
-                  <ModalStack />
+                  <RootNavigator />
                   <CodePushOverlay />
                 </Suspense>
               </Bootstrap>

--- a/client/src/lib/components/Cards/SessionCard/SessionCard.tsx
+++ b/client/src/lib/components/Cards/SessionCard/SessionCard.tsx
@@ -99,13 +99,13 @@ const SessionCard: React.FC<SessionCardProps> = ({
   const tags = useGetSessionCardTags(exercise);
 
   const onPress = useCallback(() => {
+    logSessionMetricEvent('Join Sharing Session', session); // Log before navigating for correct Origin property in event
     navigate('LiveSessionStack', {
       screen: 'ChangingRoom',
       params: {
         session,
       },
     });
-    logSessionMetricEvent('Join Sharing Session', session);
   }, [navigate, session, logSessionMetricEvent]);
 
   const onContextPress = useCallback(() => {

--- a/client/src/lib/metrics/index.tsx
+++ b/client/src/lib/metrics/index.tsx
@@ -12,6 +12,7 @@ import {PostHogMetricsProvider} from './adaptors/postHog';
 import {BackEndMetricsProvider} from './adaptors/backEnd';
 import * as postHog from './adaptors/postHog';
 import * as backEnd from './adaptors/backEnd';
+import {getCurrentRouteName} from '../navigation/utils/routes';
 
 export const MetricsProvider: MetricsProviderType = ({children}) => (
   <BackEndMetricsProvider>
@@ -31,9 +32,14 @@ export const setConsent: SetConsent = async (haveConsent: boolean) => {
 };
 
 export const logEvent: LogEvent = async (event, properties) => {
+  const props = {
+    Origin: getCurrentRouteName(), // Do not override Origin if already set
+    ...properties,
+  };
+
   await Promise.all([
-    postHog.logEvent(event, properties),
-    backEnd.logEvent(event, properties),
+    postHog.logEvent(event, props),
+    backEnd.logEvent(event, props),
   ]);
 };
 

--- a/client/src/lib/metrics/types/Adaptor.ts
+++ b/client/src/lib/metrics/types/Adaptor.ts
@@ -3,6 +3,7 @@ import CoreProperties from './CoreProperties';
 import UserProperties from './UserProperties';
 import React from 'react';
 import {Feedback} from '../../../../../shared/src/types/Feedback';
+import {DefaultProperties} from './Properties';
 
 type AnyUserProperty = Partial<UserProperties>;
 type AnyCoreProperty = Partial<CoreProperties>;
@@ -15,7 +16,9 @@ export type SetConsent = (haveConsent: boolean) => Promise<void>;
 
 export type LogEvent = <Event extends keyof Events>(
   event: Event,
-  properties: Events[Event] extends object ? Events[Event] : undefined,
+  properties: Events[Event] extends object
+    ? Events[Event] & DefaultProperties
+    : DefaultProperties,
 ) => Promise<void>;
 
 export type LogFeedback = (feedback: Feedback) => Promise<void>;

--- a/client/src/lib/metrics/types/Properties.ts
+++ b/client/src/lib/metrics/types/Properties.ts
@@ -3,8 +3,12 @@ import {LiveSession} from '../../../../../shared/src/types/Session';
 import {LANGUAGE_TAG} from '../../i18n';
 
 // General properties
+export type Origin = {Origin?: string}; // Where is the event originating from
 export type Language = {Language: LANGUAGE_TAG};
 export type Host = {Host: boolean};
+
+// Properties available to all events
+export type DefaultProperties = Origin | undefined;
 
 // Navigation properties
 export type ScreenName = {'Screen Name': string};

--- a/client/src/lib/navigation/Navigation.tsx
+++ b/client/src/lib/navigation/Navigation.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
-import {DefaultTheme, NavigationContainer} from '@react-navigation/native';
+import {
+  createNavigationContainerRef,
+  DefaultTheme,
+  NavigationContainer,
+} from '@react-navigation/native';
 
 import {COLORS} from '../../../../shared/src/constants/colors';
 import linking from './linking';
+import {RootNavigationProps} from './constants/routes';
 
 const navTheme = {
   ...DefaultTheme,
@@ -12,8 +17,11 @@ const navTheme = {
   },
 };
 
+export const navigationRef =
+  createNavigationContainerRef<RootNavigationProps>();
+
 const Navigation: React.FC<{children: React.ReactNode}> = ({children}) => (
-  <NavigationContainer theme={navTheme} linking={linking}>
+  <NavigationContainer theme={navTheme} linking={linking} ref={navigationRef}>
     {children}
   </NavigationContainer>
 );

--- a/client/src/lib/navigation/RootNavigator.tsx
+++ b/client/src/lib/navigation/RootNavigator.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ModalStack from './ModalStack';
+
+const RootNavigator = () => <ModalStack />;
+
+export default RootNavigator;

--- a/client/src/lib/navigation/constants/routes.ts
+++ b/client/src/lib/navigation/constants/routes.ts
@@ -84,3 +84,5 @@ export type ModalStackProps = {
     isHost: boolean;
   };
 };
+
+export type RootNavigationProps = ModalStackProps;

--- a/client/src/lib/navigation/linking.ts
+++ b/client/src/lib/navigation/linking.ts
@@ -9,7 +9,7 @@ import {Linking} from 'react-native';
 import {utils} from '@react-native-firebase/app';
 import {DEEP_LINK_SCHEMA, DEEP_LINK_PREFIX} from 'config';
 
-import {ModalStackProps} from './constants/routes';
+import {RootNavigationProps} from './constants/routes';
 
 const resolveNotificationUrl = async (
   source: InitialNotification | EventDetail | null,
@@ -21,7 +21,7 @@ const resolveNotificationUrl = async (
 };
 
 // Deep link configuration
-const config: LinkingOptions<ModalStackProps>['config'] = {
+const config: LinkingOptions<RootNavigationProps>['config'] = {
   initialRouteName: 'OverlayStack',
   screens: {
     AddSessionByInviteModal: 'joinSessionInvite/:inviteCode',
@@ -30,7 +30,7 @@ const config: LinkingOptions<ModalStackProps>['config'] = {
 };
 
 // Linking setup
-const linking: LinkingOptions<ModalStackProps> = {
+const linking: LinkingOptions<RootNavigationProps> = {
   config,
 
   prefixes: [DEEP_LINK_SCHEMA, DEEP_LINK_PREFIX],

--- a/client/src/lib/navigation/utils/routes.ts
+++ b/client/src/lib/navigation/utils/routes.ts
@@ -1,0 +1,11 @@
+import {navigationRef} from '../Navigation';
+
+export const getCurrentRouteName = () => {
+  const route = navigationRef.getCurrentRoute();
+
+  if (route?.params && 'screen' in route.params) {
+    return route.params.screen;
+  }
+
+  return route?.name;
+};

--- a/client/src/routes/modals/SessionModal/SessionModal.tsx
+++ b/client/src/routes/modals/SessionModal/SessionModal.tsx
@@ -173,6 +173,7 @@ const SessionModal = () => {
   const isHost = user?.uid === session.hostId;
 
   const onJoin = useCallback(() => {
+    logSessionMetricEvent('Join Sharing Session', session); // Log before navigating for correct Origin property in event
     navigation.popToTop();
     navigation.navigate('LiveSessionStack', {
       screen: 'ChangingRoom',
@@ -180,7 +181,6 @@ const SessionModal = () => {
         session: session,
       },
     });
-    logSessionMetricEvent('Join Sharing Session', session);
   }, [navigation, session, logSessionMetricEvent]);
 
   const onAddToCalendar = useCallback(() => {


### PR DESCRIPTION
[Notion issue](https://www.notion.so/29k/Early-Access-2794500652b34c64b0aff0dbbc53e0ab?pvs=4#a3c74899ef444228b6bac614fadbff7b)

Automatically adds an `Origin` property (resolved to the current route name) to all events logged by `logEvent`. Also let's you override it if you want to be more specific about it.