### PR TITLE
Track app navigations originating from a link or notification

### DIFF
--- a/client/src/lib/metrics/adaptors/backEnd/index.spec.ts
+++ b/client/src/lib/metrics/adaptors/backEnd/index.spec.ts
@@ -54,6 +54,21 @@ describe('logEvent', () => {
   });
 });
 
+describe('logNavigation', () => {
+  it('logs Screen events', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2022-02-02'));
+    jest.mocked(getMetricsUid).mockReturnValueOnce('some-metrics-uid');
+
+    await backEnd.logNavigation('Some Screen', {Origin: 'some-origin'});
+
+    expect(metricsClient).toHaveBeenCalledTimes(1);
+    expect(metricsClient).toHaveBeenCalledWith('logEvent/some-metrics-uid', {
+      body: '{"timestamp":"2022-02-02T00:00:00.000Z","event":"Screen","properties":{"Origin":"some-origin","Screen Name":"Some Screen"}}',
+      method: 'POST',
+    });
+  });
+});
+
 describe('logFeedback', () => {
   it('sends feedback to back-end', async () => {
     await backEnd.logFeeback({

--- a/client/src/lib/metrics/adaptors/backEnd/index.tsx
+++ b/client/src/lib/metrics/adaptors/backEnd/index.tsx
@@ -4,6 +4,7 @@ import {
   Init,
   LogEvent,
   LogFeedback,
+  LogNavigation,
   MetricsProvider,
   SetConsent,
   SetCoreProperties,
@@ -11,17 +12,15 @@ import {
 } from '../../types/Adaptor';
 import getMetricsUid from './utils/getMetricsUid';
 import metricsClient from './utils/metricsClient';
-import useNavigationTracker from './hooks/useNavigationTracker';
 import {DEFAULT_CONSENT} from '../../constants';
 
 let haveConsent = DEFAULT_CONSENT;
 
 let coreProperties = {};
 
-export const BackEndMetricsProvider: MetricsProvider = ({children}) => {
-  useNavigationTracker();
-  return <>{children}</>;
-};
+export const BackEndMetricsProvider: MetricsProvider = ({children}) => (
+  <>{children}</>
+);
 
 export const init: Init = async () => {};
 
@@ -44,6 +43,13 @@ export const logEvent: LogEvent = async (event, properties) => {
       }),
     });
   }
+};
+
+export const logNavigation: LogNavigation = async (screenName, properties) => {
+  await logEvent('Screen', {
+    ...properties,
+    'Screen Name': screenName,
+  });
 };
 
 export const logFeeback: LogFeedback = async feedback => {

--- a/client/src/lib/metrics/adaptors/postHog/index.spec.ts
+++ b/client/src/lib/metrics/adaptors/postHog/index.spec.ts
@@ -3,6 +3,7 @@ import type * as PostHogType from '.';
 
 const mockPostHogClient = {
   capture: jest.fn(),
+  screen: jest.fn(),
   identify: jest.fn(),
   register: jest.fn(),
   optIn: jest.fn(),
@@ -90,6 +91,24 @@ describe('logEvent', () => {
     expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1);
     expect(mockPostHogClient.capture).toHaveBeenCalledWith('Screen', {
       'Screen Name': 'some-screen',
+    });
+  });
+});
+
+describe('logNavigation', () => {
+  it('requires an init first', async () => {
+    await postHog.logNavigation('Some Screen');
+
+    expect(mockPostHogClient.screen).toHaveBeenCalledTimes(0);
+  });
+
+  it('calls capture', async () => {
+    await postHog.init();
+    await postHog.logNavigation('Some Screen', {Origin: 'some-origin'});
+
+    expect(mockPostHogClient.screen).toHaveBeenCalledTimes(1);
+    expect(mockPostHogClient.screen).toHaveBeenCalledWith('Some Screen', {
+      Origin: 'some-origin',
     });
   });
 });

--- a/client/src/lib/metrics/adaptors/postHog/index.spec.ts
+++ b/client/src/lib/metrics/adaptors/postHog/index.spec.ts
@@ -102,7 +102,7 @@ describe('logNavigation', () => {
     expect(mockPostHogClient.screen).toHaveBeenCalledTimes(0);
   });
 
-  it('calls capture', async () => {
+  it('calls screen', async () => {
     await postHog.init();
     await postHog.logNavigation('Some Screen', {Origin: 'some-origin'});
 

--- a/client/src/lib/metrics/adaptors/postHog/index.tsx
+++ b/client/src/lib/metrics/adaptors/postHog/index.tsx
@@ -6,6 +6,7 @@ import {
   Init,
   LogEvent,
   LogFeedback,
+  LogNavigation,
   MetricsProvider,
   SetCoreProperties,
   SetUserProperties,
@@ -15,7 +16,15 @@ let postHog: PostHog | undefined;
 let initPromise: Promise<PostHog> | undefined;
 
 export const PostHogMetricsProvider: MetricsProvider = ({children}) => (
-  <PostHogProvider client={postHog}>{children}</PostHogProvider>
+  <PostHogProvider
+    client={postHog}
+    autocapture={{
+      captureTouches: false,
+      captureLifecycleEvents: true,
+      captureScreens: false, // Handled by MetricsProvider
+    }}>
+    {children}
+  </PostHogProvider>
 );
 
 const initPostHog = async () => {
@@ -45,6 +54,10 @@ export const setConsent = async (haveConsent: boolean) =>
 
 export const logEvent: LogEvent = async (event, properties) => {
   await postHog?.capture(event, properties);
+};
+
+export const logNavigation: LogNavigation = async (screenName, properties) => {
+  await postHog?.screen(screenName, properties);
 };
 
 export const logFeeback: LogFeedback = async () => {};

--- a/client/src/lib/metrics/hooks/useNavigationTracker.ts
+++ b/client/src/lib/metrics/hooks/useNavigationTracker.ts
@@ -4,7 +4,7 @@
 */
 import {useNavigation, useNavigationState} from '@react-navigation/native';
 import {useCallback, useEffect} from 'react';
-import {logEvent} from '..';
+import {logNavigation} from '../';
 
 const useNavigationTracker = () => {
   const routes = useNavigationState(state => state?.routes);
@@ -25,7 +25,12 @@ const useNavigationTracker = () => {
       name = route.name;
     }
 
-    logEvent('Screen', {'Screen Name': name || 'Unknown'});
+    logNavigation(
+      name || 'Unknown',
+      currentRoute?.params?.origin && {
+        Origin: currentRoute.params.origin,
+      },
+    );
   }, [navigation]);
 
   useEffect(() => {

--- a/client/src/lib/metrics/index.spec.ts
+++ b/client/src/lib/metrics/index.spec.ts
@@ -1,6 +1,7 @@
 import {
   init,
   logEvent,
+  logNavigation,
   logFeedback,
   setConsent,
   setCoreProperties,
@@ -88,6 +89,21 @@ describe('logEvent', () => {
     expect(postHog.logEvent).toHaveBeenCalledWith('Screen', {
       Origin: 'Some Other Origin',
       'Screen Name': 'some-screen',
+    });
+  });
+});
+
+describe('logNavigation', () => {
+  it('calls backEnd and postHog adaptors', async () => {
+    await logNavigation('Some Screen', {Origin: 'some-origin'});
+
+    expect(backEnd.logNavigation).toHaveBeenCalledTimes(1);
+    expect(backEnd.logNavigation).toHaveBeenCalledWith('Some Screen', {
+      Origin: 'some-origin',
+    });
+    expect(postHog.logNavigation).toHaveBeenCalledTimes(1);
+    expect(postHog.logNavigation).toHaveBeenCalledWith('Some Screen', {
+      Origin: 'some-origin',
     });
   });
 });

--- a/client/src/lib/metrics/index.tsx
+++ b/client/src/lib/metrics/index.tsx
@@ -3,6 +3,7 @@ import {
   Init,
   LogEvent,
   LogFeedback,
+  LogNavigation,
   MetricsProvider as MetricsProviderType,
   SetConsent,
   SetCoreProperties,
@@ -13,12 +14,16 @@ import {BackEndMetricsProvider} from './adaptors/backEnd';
 import * as postHog from './adaptors/postHog';
 import * as backEnd from './adaptors/backEnd';
 import {getCurrentRouteName} from '../navigation/utils/routes';
+import useNavigationTracker from './hooks/useNavigationTracker';
 
-export const MetricsProvider: MetricsProviderType = ({children}) => (
-  <BackEndMetricsProvider>
-    <PostHogMetricsProvider>{children}</PostHogMetricsProvider>
-  </BackEndMetricsProvider>
-);
+export const MetricsProvider: MetricsProviderType = ({children}) => {
+  useNavigationTracker();
+  return (
+    <BackEndMetricsProvider>
+      <PostHogMetricsProvider>{children}</PostHogMetricsProvider>
+    </BackEndMetricsProvider>
+  );
+};
 
 export const init: Init = async () => {
   await Promise.all([postHog.init(), backEnd.init()]);
@@ -40,6 +45,13 @@ export const logEvent: LogEvent = async (event, properties) => {
   await Promise.all([
     postHog.logEvent(event, props),
     backEnd.logEvent(event, props),
+  ]);
+};
+
+export const logNavigation: LogNavigation = async (screenName, properties) => {
+  await Promise.all([
+    postHog.logNavigation(screenName, properties),
+    backEnd.logNavigation(screenName, properties),
   ]);
 };
 

--- a/client/src/lib/metrics/types/Adaptor.ts
+++ b/client/src/lib/metrics/types/Adaptor.ts
@@ -21,6 +21,11 @@ export type LogEvent = <Event extends keyof Events>(
     : DefaultProperties,
 ) => Promise<void>;
 
+export type LogNavigation = (
+  screenName: string,
+  properties?: Omit<Events['Screen'], 'Screen Name'> & DefaultProperties,
+) => Promise<void>;
+
 export type LogFeedback = (feedback: Feedback) => Promise<void>;
 
 export type SetUserProperties = (

--- a/client/src/lib/navigation/linkHandlers/dynamicLinks.ts
+++ b/client/src/lib/navigation/linkHandlers/dynamicLinks.ts
@@ -1,0 +1,20 @@
+import dynamicLinks from '@react-native-firebase/dynamic-links';
+import {utils} from '@react-native-firebase/app';
+import {appendOrigin} from './utils';
+
+export const getInitialURL = async () => {
+  const {isAvailable} = utils().playServicesAvailability;
+
+  if (isAvailable) {
+    const dynamicLink = await dynamicLinks().getInitialLink();
+
+    if (dynamicLink) {
+      return appendOrigin(dynamicLink.url, 'link');
+    }
+  }
+};
+
+export const addEventListener = (handler: (url: string) => void) =>
+  dynamicLinks().onLink(({url}) => {
+    handler(appendOrigin(url, 'link'));
+  });

--- a/client/src/lib/navigation/linkHandlers/nativeLinks.ts
+++ b/client/src/lib/navigation/linkHandlers/nativeLinks.ts
@@ -1,0 +1,17 @@
+import {Linking} from 'react-native';
+import {appendOrigin} from './utils';
+
+export const getInitialURL = async () => {
+  const url = await Linking.getInitialURL();
+  if (url) {
+    return appendOrigin(url, 'link');
+  }
+};
+
+export const addEventListener = (handler: (url: string) => void) => {
+  const subscription = Linking.addEventListener('url', ({url}) => {
+    handler(appendOrigin(url, 'link'));
+  });
+
+  return () => subscription.remove();
+};

--- a/client/src/lib/navigation/linkHandlers/notifications.ts
+++ b/client/src/lib/navigation/linkHandlers/notifications.ts
@@ -19,7 +19,7 @@ const resolveNotificationUrl = async (
 };
 
 export const getInitialURL = async () =>
-  resolveNotificationUrl(await notifee.getInitialNotification());
+  await resolveNotificationUrl(await notifee.getInitialNotification());
 
 export const addEventListener = (handler: (url: string) => void) =>
   notifee.onForegroundEvent(async ({type, detail}) => {

--- a/client/src/lib/navigation/linkHandlers/notifications.ts
+++ b/client/src/lib/navigation/linkHandlers/notifications.ts
@@ -1,0 +1,32 @@
+import dynamicLinks from '@react-native-firebase/dynamic-links';
+import notifee, {
+  EventDetail,
+  EventType,
+  InitialNotification,
+} from '@notifee/react-native';
+import {appendOrigin} from './utils';
+
+const resolveNotificationUrl = async (
+  source: InitialNotification | EventDetail | null,
+): Promise<string | undefined> => {
+  const url = source?.notification?.data?.url as string;
+  if (url) {
+    return appendOrigin(
+      (await dynamicLinks().resolveLink(url)).url,
+      'notification',
+    );
+  }
+};
+
+export const getInitialURL = async () =>
+  resolveNotificationUrl(await notifee.getInitialNotification());
+
+export const addEventListener = (handler: (url: string) => void) =>
+  notifee.onForegroundEvent(async ({type, detail}) => {
+    if (type === EventType.PRESS) {
+      const url = await resolveNotificationUrl(detail);
+      if (url) {
+        handler(url);
+      }
+    }
+  });

--- a/client/src/lib/navigation/linkHandlers/utils.spec.ts
+++ b/client/src/lib/navigation/linkHandlers/utils.spec.ts
@@ -1,0 +1,13 @@
+import {appendOrigin} from './utils';
+
+describe('appendOrigin', () => {
+  it('adds origin search param to url', () => {
+    expect(appendOrigin('https://29k.org', 'interwebz')).toBe(
+      'https://29k.org/?origin=interwebz',
+    );
+  });
+
+  it('throws on invalid URL', () => {
+    expect(() => appendOrigin('', 'interwebz')).toThrowError('Invalid URL');
+  });
+});

--- a/client/src/lib/navigation/linkHandlers/utils.ts
+++ b/client/src/lib/navigation/linkHandlers/utils.ts
@@ -1,0 +1,6 @@
+export const appendOrigin = (url: string, origin: string) => {
+  const urlObject = new URL(url);
+  urlObject.searchParams.append('origin', origin);
+
+  return urlObject.toString();
+};

--- a/client/src/lib/navigation/linking.ts
+++ b/client/src/lib/navigation/linking.ts
@@ -1,24 +1,11 @@
 import {LinkingOptions} from '@react-navigation/native';
-import dynamicLinks from '@react-native-firebase/dynamic-links';
-import notifee, {
-  EventDetail,
-  EventType,
-  InitialNotification,
-} from '@notifee/react-native';
-import {Linking} from 'react-native';
-import {utils} from '@react-native-firebase/app';
 import {DEEP_LINK_SCHEMA, DEEP_LINK_PREFIX} from 'config';
 
-import {ModalStackProps} from './constants/routes';
+import * as dynamicLinks from './linkHandlers/dynamicLinks';
+import * as notifications from './linkHandlers/notifications';
+import * as nativeLinks from './linkHandlers/nativeLinks';
 
-const resolveNotificationUrl = async (
-  source: InitialNotification | EventDetail | null,
-): Promise<string | undefined> => {
-  const url = source?.notification?.data?.url as string;
-  if (url) {
-    return (await dynamicLinks().resolveLink(url)).url;
-  }
-};
+import {ModalStackProps} from './constants/routes';
 
 // Deep link configuration
 const config: LinkingOptions<ModalStackProps>['config'] = {
@@ -29,70 +16,39 @@ const config: LinkingOptions<ModalStackProps>['config'] = {
   },
 };
 
-// Linking setup
 const linking: LinkingOptions<ModalStackProps> = {
   config,
 
   prefixes: [DEEP_LINK_SCHEMA, DEEP_LINK_PREFIX],
 
-  // Custom function to get the URL which was used to open the app
   async getInitialURL() {
-    // First, you would need to get the initial URL from your third-party integration
-    // The exact usage depend on the third-party SDK you use
-    // For example, to get to get the initial URL for Firebase Dynamic Links:
-    const {isAvailable} = utils().playServicesAvailability;
-
-    if (isAvailable) {
-      const initialLink = await dynamicLinks().getInitialLink();
-
-      if (initialLink) {
-        return initialLink.url;
-      }
+    const dynamicLinkURL = await dynamicLinks.getInitialURL();
+    if (dynamicLinkURL) {
+      return dynamicLinkURL;
     }
 
-    // Second, check for the app being opened from a notification
-    const notificationUrl = await resolveNotificationUrl(
-      await notifee.getInitialNotification(),
-    );
-    if (notificationUrl) {
-      return notificationUrl;
+    const notificationURL = await notifications.getInitialURL();
+    if (notificationURL) {
+      return notificationURL;
     }
 
-    // As a fallback, you may want to do the default deep link handling
-    const url = await Linking.getInitialURL();
-
-    return url;
+    const nativeLinkURL = await nativeLinks.getInitialURL();
+    if (nativeLinkURL) {
+      return nativeLinkURL;
+    }
   },
 
-  // Custom function to subscribe to incoming links
   subscribe(listener) {
-    // Listen to incoming links from Firebase Dynamic Links
-    const unsubscribeFirebase = dynamicLinks().onLink(({url}) => {
-      listener(url);
-    });
+    const unsubscribeDynamicLinks = dynamicLinks.addEventListener(listener);
 
-    // Listen to incoming links from Notifee notifications
-    const unsubscribeNotifee = notifee.onForegroundEvent(
-      async ({type, detail}) => {
-        if (type === EventType.PRESS) {
-          const url = await resolveNotificationUrl(detail);
-          if (url) {
-            listener(url);
-          }
-        }
-      },
-    );
+    const unsubscribeNotifications = notifications.addEventListener(listener);
 
-    // Listen to incoming links from deep linking
-    const linkingSubscription = Linking.addEventListener('url', ({url}) => {
-      listener(url);
-    });
+    const unsubscribeNativeLinks = nativeLinks.addEventListener(listener);
 
     return () => {
-      // Clean up the event listeners
-      unsubscribeFirebase();
-      unsubscribeNotifee();
-      linkingSubscription.remove();
+      unsubscribeDynamicLinks();
+      unsubscribeNotifications();
+      unsubscribeNativeLinks();
     };
   },
 };


### PR DESCRIPTION
This appends `Origin: 'link'` or `Origin: 'notification'` to `Screen` (navigation) events, so we can track how many opens the app from a link or a notification.

It basically works by appending a query argument to the opened url. 
1. Opening the link `https://29k.org/joinSessionInvite/123456` from a notification 
2. Translates into `https://29k.org/joinSessionInvite/123456?origin=notification` 
3. Translates into a react navigation route param `{ origin: 'notification' }`
4. Translates into a `Screen { ‘Screen Name’: ‘AddSessionByInviteModal’, Origin: 'notification' }` metrics event