### PR TITLE
Track Add Collection To Journey

### DIFF
--- a/client/src/lib/metrics/types/Events.ts
+++ b/client/src/lib/metrics/types/Events.ts
@@ -4,6 +4,7 @@ import {
   FeedbackProperties,
   ScreenName,
   SharingSessionPost,
+  CollectionProperties,
 } from './Properties';
 
 type Events = {
@@ -37,6 +38,9 @@ type Events = {
 
   // Feedback
   'Sharing Session Feedback': FeedbackProperties;
+
+  // Collections
+  'Add Collection To Journey': CollectionProperties;
 };
 
 export default Events;

--- a/client/src/lib/metrics/types/Properties.ts
+++ b/client/src/lib/metrics/types/Properties.ts
@@ -46,3 +46,7 @@ export type FeedbackProperties = {
   'Sharing Session Completed': boolean;
   Host?: boolean;
 } & ExerciseID;
+
+// Feedback properties
+export type CollectionID = {'Collection ID': string};
+export type CollectionProperties = CollectionID;

--- a/client/src/lib/user/hooks/usePinCollection.spec.ts
+++ b/client/src/lib/user/hooks/usePinCollection.spec.ts
@@ -1,7 +1,12 @@
 import {FirebaseAuthTypes} from '@react-native-firebase/auth';
 import {act, renderHook} from '@testing-library/react-hooks';
+import {logEvent} from '../../metrics';
 import useUserState from '../state/state';
 import usePinCollection from './usePinCollection';
+
+const mockLogEvent = jest.mocked(logEvent);
+
+jest.mock('../../metrics');
 
 jest.mock(
   '../../content/hooks/useGetCollectionById',
@@ -35,6 +40,10 @@ describe('usePinCollection', () => {
         },
       }),
     );
+    expect(mockLogEvent).toHaveBeenCalledTimes(1);
+    expect(mockLogEvent).toHaveBeenCalledWith('Add Collection To Journey', {
+      'Collection ID': 'some-collection-id',
+    });
   });
 
   it('should remove collection as pinned', () => {

--- a/client/src/lib/user/hooks/usePinCollection.ts
+++ b/client/src/lib/user/hooks/usePinCollection.ts
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import useUserState from '../state/state';
 import usePinnedCollections from './usePinnedCollections';
+import * as metrics from '../../metrics';
 
 dayjs.extend(utc);
 
@@ -25,6 +26,9 @@ const usePinCollection = (collectionId: string) => {
           startedAt: dayjs().utc().toJSON(),
         },
       ]);
+      metrics.logEvent('Add Collection To Journey', {
+        'Collection ID': collectionId,
+      });
     }
   }, [collectionId, setPinnedCollections, pinnedCollections]);
 


### PR DESCRIPTION
Adds metric event for adding collection to journey
```
 DEBUG  client:metrics logEvent Add Collection To Journey {
  "Origin": "Collection",
  "Collection ID": "c4e29d4b-85d0-4c4d-8449-af8d77156278"
} +2s
```