### PR TITLE
Datepicker minimum date time

### DIFF
--- a/client/src/lib/components/DateTimePicker/DateTimePicker.tsx
+++ b/client/src/lib/components/DateTimePicker/DateTimePicker.tsx
@@ -118,33 +118,15 @@ const Picker: React.FC<PickerProps> = ({
     onChange(selectedDateTime, selectedDateTime);
   }, [selectedDateTime, minimumDate, onChange]);
 
-  const onSetDate: DateTimePickerProps['setValue'] = useCallback(
+  const setDateTime: DateTimePickerProps['setValue'] = useCallback(
     value => {
-      let sessionDateTime = value
-        .hour(selectedDateTime.hour())
-        .minute(selectedDateTime.minute());
-
-      if (minimumDate && sessionDateTime.isBefore(minimumDate.utc())) {
-        sessionDateTime = minimumDate.utc();
-      }
-
-      setSelectedDateTime(sessionDateTime);
+      setSelectedDateTime(
+        minimumDate && value.isBefore(minimumDate.utc())
+          ? minimumDate.utc()
+          : value,
+      );
     },
-    [minimumDate, selectedDateTime],
-  );
-  const onSetTime: DateTimePickerProps['setValue'] = useCallback(
-    value => {
-      let sessionDateTime = selectedDateTime
-        .hour(value.hour())
-        .minute(value.minute());
-
-      if (minimumDate && sessionDateTime.isBefore(minimumDate.utc())) {
-        sessionDateTime = minimumDate.utc();
-      }
-
-      setSelectedDateTime(sessionDateTime);
-    },
-    [minimumDate, selectedDateTime],
+    [minimumDate],
   );
 
   const onDatePress = useCallback(() => {
@@ -179,7 +161,7 @@ const Picker: React.FC<PickerProps> = ({
           <DateTimePicker
             mode="date"
             selectedValue={selectedDateTime}
-            setValue={onSetDate}
+            setValue={setDateTime}
             close={onClose}
             minimumDate={minimumDate}
             maximumDate={maximumDate}
@@ -198,7 +180,7 @@ const Picker: React.FC<PickerProps> = ({
             mode="time"
             minimumDate={minimumDate}
             selectedValue={selectedDateTime}
-            setValue={onSetTime}
+            setValue={setDateTime}
             close={onClose}
           />
         )}

--- a/client/src/lib/components/DateTimePicker/DateTimePicker.tsx
+++ b/client/src/lib/components/DateTimePicker/DateTimePicker.tsx
@@ -124,8 +124,8 @@ const Picker: React.FC<PickerProps> = ({
         .hour(selectedDateTime.hour())
         .minute(selectedDateTime.minute());
 
-      if (minimumDate && sessionDateTime.isBefore(minimumDate)) {
-        sessionDateTime = minimumDate;
+      if (minimumDate && sessionDateTime.isBefore(minimumDate.utc())) {
+        sessionDateTime = minimumDate.utc();
       }
 
       setSelectedDateTime(sessionDateTime);
@@ -138,8 +138,8 @@ const Picker: React.FC<PickerProps> = ({
         .hour(value.hour())
         .minute(value.minute());
 
-      if (minimumDate && sessionDateTime.isBefore(minimumDate)) {
-        sessionDateTime = minimumDate;
+      if (minimumDate && sessionDateTime.isBefore(minimumDate.utc())) {
+        sessionDateTime = minimumDate.utc();
       }
 
       setSelectedDateTime(sessionDateTime);
@@ -155,14 +155,14 @@ const Picker: React.FC<PickerProps> = ({
 
   const onTimePress = useCallback(() => {
     setShowDatePicker(false);
-    setShowTimePicker(!showDatePicker);
-    onToggle(!showDatePicker);
-  }, [setShowTimePicker, showDatePicker, onToggle]);
+    setShowTimePicker(!showTimePicker);
+    onToggle(!showTimePicker);
+  }, [setShowTimePicker, showTimePicker, onToggle]);
 
-  const onClose = useCallback(
-    () => setShowDatePicker(false),
-    [setShowDatePicker],
-  );
+  const onClose = useCallback(() => {
+    setShowDatePicker(false);
+    setShowTimePicker(false);
+  }, [setShowDatePicker]);
 
   return (
     <>

--- a/client/src/lib/components/DateTimePicker/DateTimePicker.tsx
+++ b/client/src/lib/components/DateTimePicker/DateTimePicker.tsx
@@ -2,13 +2,7 @@ import RNDateTimePicker, {
   DateTimePickerEvent,
 } from '@react-native-community/datetimepicker';
 import dayjs from 'dayjs';
-import React, {
-  Dispatch,
-  SetStateAction,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {Platform} from 'react-native';
 import styled from 'styled-components/native';
 import utc from 'dayjs/plugin/utc';

--- a/client/src/routes/modals/CreateSessionModal/components/steps/SetDateTimeStep.tsx
+++ b/client/src/routes/modals/CreateSessionModal/components/steps/SetDateTimeStep.tsx
@@ -57,24 +57,19 @@ const SetDateTimeStep: React.FC<StepProps> = ({
   const {goBack, navigate} =
     useNavigation<NativeStackNavigationProp<ModalStackProps, 'SessionModal'>>();
   const [isLoading, setIsLoading] = useState(false);
-  const [date, setDate] = useState<dayjs.Dayjs | undefined>();
-  const [time, setTime] = useState<dayjs.Dayjs | undefined>();
+  const [sessionDateTime, setSessionDateTime] = useState<dayjs.Dayjs>(dayjs());
+
   const {addSession} = useSessions();
   const exercise = useExerciseById(selectedExercise);
   const logSessionMetricEvent = useLogSessionMetricEvents();
 
   const onChange = useCallback(
-    (selectedDate: dayjs.Dayjs, selectedTime: dayjs.Dayjs) => {
-      setDate(selectedDate);
-      setTime(selectedTime);
-    },
-    [setDate, setTime],
+    (selectedDateTime: dayjs.Dayjs) => setSessionDateTime(selectedDateTime),
+    [setSessionDateTime],
   );
 
   const onSubmit = useCallback(async () => {
-    if (selectedExercise && selectedModeAndType?.type && date && time) {
-      const sessionDateTime = date.hour(time.hour()).minute(time.minute());
-
+    if (selectedExercise && selectedModeAndType?.type) {
       setIsLoading(true);
       const session = await addSession({
         exerciseId: selectedExercise,
@@ -88,10 +83,9 @@ const SetDateTimeStep: React.FC<StepProps> = ({
       navigate('SessionModal', {session});
     }
   }, [
+    sessionDateTime,
     selectedExercise,
     selectedModeAndType,
-    date,
-    time,
     addSession,
     goBack,
     navigate,

--- a/client/src/routes/modals/SessionModal/SessionModal.tsx
+++ b/client/src/routes/modals/SessionModal/SessionModal.tsx
@@ -417,7 +417,7 @@ const SessionModal = () => {
               )}
               <DateTimePicker
                 initialDateTime={initialStartTime}
-                minimumDate={dayjs().local()}
+                minimumDate={dayjs()}
                 onChange={onChange}
               />
               <Spacer16 />

--- a/client/src/routes/modals/SessionModal/SessionModal.tsx
+++ b/client/src/routes/modals/SessionModal/SessionModal.tsx
@@ -153,8 +153,8 @@ const SessionModal = () => {
   const [selectedType, setSelectedType] = useState(session?.type);
 
   const initialStartTime = dayjs(session.startTime).utc();
-  const [sessionDate, setSessionDate] = useState<dayjs.Dayjs>(initialStartTime);
-  const [sessionTime, setSessionTime] = useState<dayjs.Dayjs>(initialStartTime);
+  const [sessionDateTime, setSessionDateTime] =
+    useState<dayjs.Dayjs>(initialStartTime);
   const {togglePinned, isPinned} = usePinSession(session);
   const logSessionMetricEvent = useLogSessionMetricEvents();
 
@@ -231,10 +231,6 @@ const SessionModal = () => {
   }, [t, navigation, deleteSession, session.id]);
 
   const onUpdateSession = useCallback(async () => {
-    const sessionDateTime = sessionDate
-      .hour(sessionTime.hour())
-      .minute(sessionTime.minute());
-
     const updatedSession = await updateSession(session.id, {
       startTime: sessionDateTime.utc().toISOString(),
       type: selectedType,
@@ -247,18 +243,14 @@ const SessionModal = () => {
     setSession,
     fetchSessions,
     setEditMode,
-    sessionTime,
-    sessionDate,
     session.id,
     selectedType,
+    sessionDateTime,
   ]);
 
   const onChange = useCallback(
-    (date: dayjs.Dayjs, time: dayjs.Dayjs) => {
-      setSessionDate(date);
-      setSessionTime(time);
-    },
-    [setSessionDate, setSessionTime],
+    (dateTime: dayjs.Dayjs) => setSessionDateTime(dateTime),
+    [setSessionDateTime],
   );
 
   const onEditMode = useCallback(() => setEditMode(true), [setEditMode]);


### PR DESCRIPTION
Issue: [exp was '1678462106', which is in the past rather than in the future](https://29k-international-ab.sentry.io/issues/3993636243/?project=6617535&query=correlation_id%3A5xvbemaj5z+correlation_id%3A5xvbemaj5z&referrer=issue-stream)

### Description of the Change

It is currently possible to choose a time in the past, which doesn't make sense plus causes an error on the daily api cause it doesn't accept rooms that have their expiry date in the past.

#### ios

https://user-images.githubusercontent.com/7523828/224497689-75b38b06-a847-4e66-ae38-c28f1abe7424.mp4

#### android

https://user-images.githubusercontent.com/7523828/224506334-91b7b22e-217c-4ebe-ae20-9c0ca4ef08f2.mov






