### PR TITLE
Track lifecycle events

### DIFF
--- a/client/src/lib/metrics/adaptors/postHog/index.tsx
+++ b/client/src/lib/metrics/adaptors/postHog/index.tsx
@@ -20,7 +20,7 @@ export const PostHogMetricsProvider: MetricsProvider = ({children}) => (
     client={postHog}
     autocapture={{
       captureTouches: false,
-      captureLifecycleEvents: true,
+      captureLifecycleEvents: false, // Handled by MetricsProvider
       captureScreens: false, // Handled by MetricsProvider
     }}>
     {children}

--- a/client/src/lib/metrics/hooks/useLifecycleTracker.ts
+++ b/client/src/lib/metrics/hooks/useLifecycleTracker.ts
@@ -1,0 +1,32 @@
+/*
+  This hook is heavily inspired by
+  https://github.com/PostHog/posthog-js-lite/blob/master/posthog-react-native/src/hooks/useLifecycleTracker.ts
+*/
+import {useEffect, useRef} from 'react';
+import {AppState} from 'react-native';
+import {logEvent} from '../';
+
+const useLifecycleTracker = () => {
+  const openTrackedRef = useRef(false);
+
+  useEffect(() => {
+    if (!openTrackedRef.current) {
+      openTrackedRef.current = true;
+      logEvent('Application Opened', undefined);
+    }
+    const subscription = AppState.addEventListener('change', nextAppState => {
+      switch (nextAppState) {
+        case 'active':
+          return logEvent('Application Became Active', undefined);
+        case 'background':
+          return logEvent('Application Backgrounded', undefined);
+        default:
+          return;
+      }
+    });
+
+    return () => subscription.remove();
+  }, []);
+};
+
+export default useLifecycleTracker;

--- a/client/src/lib/metrics/index.tsx
+++ b/client/src/lib/metrics/index.tsx
@@ -16,10 +16,12 @@ import * as postHog from './adaptors/postHog';
 import * as backEnd from './adaptors/backEnd';
 import {getCurrentRouteName} from '../navigation/utils/routes';
 import useNavigationTracker from './hooks/useNavigationTracker';
+import useLifecycleTracker from './hooks/useLifecycleTracker';
 
 const logDebug = debug('client:metrics');
 
 export const MetricsProvider: MetricsProviderType = ({children}) => {
+  useLifecycleTracker();
   useNavigationTracker();
   return (
     <BackEndMetricsProvider>

--- a/client/src/lib/metrics/types/Events.ts
+++ b/client/src/lib/metrics/types/Events.ts
@@ -8,6 +8,11 @@ import {
 } from './Properties';
 
 type Events = {
+  // Application lifecycle events
+  'Application Opened': undefined;
+  'Application Became Active': undefined;
+  'Application Backgrounded': undefined;
+
   // Navigation
   Screen: ScreenName;
   'Open Link': {URL: string};


### PR DESCRIPTION
[Todo in notion](https://www.notion.so/29k/Early-Access-2794500652b34c64b0aff0dbbc53e0ab?pvs=4#665cf27d0af34d308435852698f8cff9)
Adds general application lifecycle events to both PostHog and Back-end metrics logging
*  `Application Opened`
*  `Application Became Active`
*  `Application Backgrounded`