### PR TITLE
Non authorized api routes

### DIFF
--- a/client/src/lib/apiClient/apiClient.spec.ts
+++ b/client/src/lib/apiClient/apiClient.spec.ts
@@ -50,6 +50,25 @@ describe('apiClient', () => {
     });
   });
 
+  it('does not add authorization header when authorize = false', async () => {
+    mockedGetAuthorizationToken.mockResolvedValueOnce(
+      'some-authorization-token',
+    );
+
+    await apiClient('/some-path', undefined, false);
+
+    expect(getAuthorizationToken).toHaveBeenCalledTimes(0);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('some-api-endpoint/some-path', {
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept-Language': 'en',
+        'X-Correlation-ID': expect.any(String),
+      },
+    });
+  });
+
   it('recreates user when server responds with 401 and calls server again', async () => {
     mockedGetAuthorizationToken.mockResolvedValueOnce(
       'some-authorization-token',

--- a/client/src/lib/killSwitch/hooks/useKillSwitch.ts
+++ b/client/src/lib/killSwitch/hooks/useKillSwitch.ts
@@ -40,7 +40,7 @@ const useKillSwitch = () => {
       setState({isLoading: true});
 
       try {
-        return await apiClient(url);
+        return await apiClient(url, undefined, false);
       } catch (cause: any) {
         // Do not block the user on network issues
         setState({

--- a/functions/src/api/index.ts
+++ b/functions/src/api/index.ts
@@ -1,6 +1,7 @@
 import {onRequest} from 'firebase-functions/v2/https';
 import Koa from 'koa';
 
+import {createApiPreAuthRouter, createApiAuthRouter} from '../lib/routers';
 import {killSwitchRouter} from './killswitch';
 import {sessionsRouter} from './sessions';
 import {userRouter} from './user';
@@ -10,7 +11,6 @@ import sentryErrorHandler from '../lib/sentry';
 import firebaseBodyParser from '../lib/firebaseBodyParser';
 import languageResolver from './lib/languageResolver';
 import firebaseAuth from './lib/firebaseAuth';
-import {createApiRouter} from '../lib/routers';
 import localErrorHandler from '../lib/localErrorHandler';
 
 const app = new Koa();
@@ -18,10 +18,12 @@ const app = new Koa();
 app.on('error', sentryErrorHandler);
 app.on('error', localErrorHandler);
 
-const rootRouter = createApiRouter();
-rootRouter
+const preAuthRouter = createApiPreAuthRouter();
+preAuthRouter.use('/killSwitch', killSwitchRouter.routes());
+
+const authRouter = createApiAuthRouter();
+authRouter
   .use('/sessions', sessionsRouter.routes())
-  .use('/killSwitch', killSwitchRouter.routes())
   .use('/user', userRouter.routes())
   .use('/posts', postsRouter.routes())
   .use('/report', reportRouter.routes());
@@ -29,9 +31,11 @@ rootRouter
 app
   .use(firebaseBodyParser())
   .use(languageResolver())
+  .use(preAuthRouter.routes())
+  .use(preAuthRouter.allowedMethods())
   .use(firebaseAuth())
-  .use(rootRouter.routes())
-  .use(rootRouter.allowedMethods());
+  .use(authRouter.routes())
+  .use(authRouter.allowedMethods());
 
 export const api = onRequest(
   {

--- a/functions/src/api/killswitch/index.spec.ts
+++ b/functions/src/api/killswitch/index.spec.ts
@@ -3,7 +3,7 @@ import request from 'supertest';
 import {killSwitchRouter} from './index';
 import createMockServer from '../lib/createMockServer';
 
-import {createApiRouter} from '../../lib/routers';
+import {createApiAuthRouter} from '../../lib/routers';
 
 jest.mock('../../../../content/content.json', () => ({
   i18n: {
@@ -52,7 +52,7 @@ jest.mock('../../../../content/content.json', () => ({
   },
 }));
 
-const router = createApiRouter();
+const router = createApiAuthRouter();
 router.use('/killSwitch', killSwitchRouter.routes());
 const mockServer = createMockServer(router.routes(), router.allowedMethods());
 

--- a/functions/src/api/killswitch/index.ts
+++ b/functions/src/api/killswitch/index.ts
@@ -1,7 +1,7 @@
 import * as yup from 'yup';
 import validator from 'koa-yup-validator';
 import {lt, valid} from 'semver';
-import {createApiRouter} from '../../lib/routers';
+import {createApiPreAuthRouter} from '../../lib/routers';
 import i18next from '../../lib/i18n';
 
 // Binary kill switch, this will permanently disable the entire app.
@@ -43,7 +43,7 @@ const acceptedBundleVersion = (
   return bundleVersionNumber >= MIN_BUNDLE_VERSION[version][platform];
 };
 
-const router = createApiRouter();
+const router = createApiPreAuthRouter();
 
 type RequestQuery = {
   version: string;

--- a/functions/src/api/posts/index.spec.ts
+++ b/functions/src/api/posts/index.spec.ts
@@ -3,7 +3,7 @@ import Koa from 'koa';
 
 import {postsRouter} from '.';
 import createMockServer from '../lib/createMockServer';
-import {createApiRouter} from '../../lib/routers';
+import {createApiAuthRouter} from '../../lib/routers';
 
 import {
   createPost,
@@ -17,7 +17,7 @@ const mockCreatePost = jest.mocked(createPost);
 const mockDeletePost = jest.mocked(deletePost);
 const mockGetPostsByExerciseId = jest.mocked(getPostsByExerciseAndSharingId);
 
-const router = createApiRouter();
+const router = createApiAuthRouter();
 router.use('/posts', postsRouter.routes());
 const mockServer = createMockServer(
   async (ctx: Koa.Context, next: Koa.Next) => {

--- a/functions/src/api/posts/index.ts
+++ b/functions/src/api/posts/index.ts
@@ -1,7 +1,7 @@
 import * as yup from 'yup';
 import validator from 'koa-yup-validator';
 
-import {createApiRouter} from '../../lib/routers';
+import {createApiAuthRouter} from '../../lib/routers';
 import {PostError} from '../../../../shared/src/errors/Post';
 import {
   createPost,
@@ -10,7 +10,7 @@ import {
 } from '../../controllers/posts';
 import {RequestError} from '../../controllers/errors/RequestError';
 
-const postsRouter = createApiRouter();
+const postsRouter = createApiAuthRouter();
 
 const POSTS_LIMIT = 20;
 

--- a/functions/src/api/report/index.spec.ts
+++ b/functions/src/api/report/index.spec.ts
@@ -3,14 +3,14 @@ import Koa from 'koa';
 
 import {reportRouter} from '.';
 import createMockServer from '../lib/createMockServer';
-import {createApiRouter} from '../../lib/routers';
+import {createApiAuthRouter} from '../../lib/routers';
 
 import * as reportController from '../../controllers/report';
 
 jest.mock('../../controllers/report');
 const mockCreateReport = jest.mocked(reportController.createReport);
 
-const router = createApiRouter();
+const router = createApiAuthRouter();
 router.use('/report', reportRouter.routes());
 const mockServer = createMockServer(
   async (ctx: Koa.Context, next: Koa.Next) => {

--- a/functions/src/api/report/index.ts
+++ b/functions/src/api/report/index.ts
@@ -1,11 +1,11 @@
 import * as yup from 'yup';
 import validator from 'koa-yup-validator';
 
-import {createApiRouter} from '../../lib/routers';
+import {createApiAuthRouter} from '../../lib/routers';
 
 import {createReport} from '../../controllers/report';
 
-const reportRouter = createApiRouter();
+const reportRouter = createApiAuthRouter();
 
 const ReportParamsSchema = yup.object().shape({
   screen: yup.string(),

--- a/functions/src/api/sessions/index.spec.ts
+++ b/functions/src/api/sessions/index.spec.ts
@@ -3,7 +3,7 @@ import Koa from 'koa';
 
 import {sessionsRouter} from '.';
 import createMockServer from '../lib/createMockServer';
-import {createApiRouter} from '../../lib/routers';
+import {createApiAuthRouter} from '../../lib/routers';
 import {ROLES} from '../../../../shared/src/types/User';
 import * as sessionsController from '../../controllers/sessions';
 import {RequestError} from '../../controllers/errors/RequestError';
@@ -29,7 +29,7 @@ const mockGetSession = sessionsController.getSession as jest.Mock;
 jest.mock('../../models/session');
 
 const getMockCustomClaims = jest.fn();
-const router = createApiRouter();
+const router = createApiAuthRouter();
 router.use('/sessions', sessionsRouter.routes());
 const mockServer = createMockServer(
   async (ctx: Koa.Context, next: Koa.Next) => {

--- a/functions/src/api/sessions/index.ts
+++ b/functions/src/api/sessions/index.ts
@@ -3,7 +3,7 @@ import validator from 'koa-yup-validator';
 import 'firebase-functions';
 
 import {SessionType} from '../../../../shared/src/types/Session';
-import {createApiRouter} from '../../lib/routers';
+import {createApiAuthRouter} from '../../lib/routers';
 import restrictAccessToRole from '../lib/restrictAccessToRole';
 
 import * as sessionsController from '../../controllers/sessions';
@@ -18,7 +18,7 @@ import {
 } from '../../../../shared/src/errors/Session';
 import {RequestError} from '../../controllers/errors/RequestError';
 
-const sessionsRouter = createApiRouter();
+const sessionsRouter = createApiAuthRouter();
 
 sessionsRouter.get('/', async ctx => {
   const {response, user, query} = ctx;

--- a/functions/src/api/user/index.spec.ts
+++ b/functions/src/api/user/index.spec.ts
@@ -3,7 +3,7 @@ import Koa from 'koa';
 
 import {userRouter} from '.';
 import createMockServer from '../lib/createMockServer';
-import {createApiRouter} from '../../lib/routers';
+import {createApiAuthRouter} from '../../lib/routers';
 
 import {
   requestPublicHostRole,
@@ -22,7 +22,7 @@ jest.mock('../../controllers/user');
 const mockRequestPublicHostRole = requestPublicHostRole as jest.Mock;
 const mockVerifyRequest = verifyPublicHostRequest as jest.Mock;
 
-const router = createApiRouter();
+const router = createApiAuthRouter();
 router.use('/user', userRouter.routes());
 const mockServer = createMockServer(
   async (ctx: Koa.Context, next: Koa.Next) => {

--- a/functions/src/api/user/index.ts
+++ b/functions/src/api/user/index.ts
@@ -1,7 +1,7 @@
 import * as yup from 'yup';
 import validator from 'koa-yup-validator';
 
-import {createApiRouter} from '../../lib/routers';
+import {createApiAuthRouter} from '../../lib/routers';
 import {
   UserProfileError,
   VerificationError,
@@ -13,7 +13,7 @@ import {
 import {RequestError} from '../../controllers/errors/RequestError';
 import {getProfile} from '../../controllers/user';
 
-const userRouter = createApiRouter();
+const userRouter = createApiAuthRouter();
 
 userRouter.post('/requestPublicHost', async ctx => {
   const {id} = ctx.user;

--- a/functions/src/lib/routers.ts
+++ b/functions/src/lib/routers.ts
@@ -4,7 +4,10 @@ import {FirebaseAuthContext} from '../api/lib/firebaseAuth';
 import {LanguageContext} from '../api/lib/languageResolver';
 import {SlackContext} from '../slack/lib/verifySlackRequest';
 
-export const createApiRouter = () =>
+export const createApiPreAuthRouter = () =>
+  new Router<DefaultState, LanguageContext>();
+
+export const createApiAuthRouter = () =>
   new Router<DefaultState, LanguageContext & FirebaseAuthContext>();
 
 export const createSlackRouter = () => new Router<DefaultState, SlackContext>();


### PR DESCRIPTION
For the upcoming onboarding we want to create an anonymous user as late as possible. Today `killSwitch` requires a user and an authorization token. This adds the possibility to have non authorized api routes.

- [x] Add `preAuthRouter` support to api for routes that doesn't require authorization
- [x] Add support for non authorized api requests in `apiClient` with `authorize = false`
- [x] Change `killSwitch` to be a non authorized route