### PR TITLE
Upcoming public sessions

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -75,6 +75,24 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "ended",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "startTime",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "ended",
           "order": "ASCENDING"
         },

--- a/functions/src/api/index.ts
+++ b/functions/src/api/index.ts
@@ -3,10 +3,11 @@ import Koa from 'koa';
 
 import {createApiPreAuthRouter, createApiAuthRouter} from '../lib/routers';
 import {killSwitchRouter} from './killswitch';
-import {sessionsRouter, sessionsPreAuthRouter} from './sessions';
+import {sessionsRouter} from './sessions';
 import {userRouter} from './user';
 import {postsRouter} from './posts';
 import {reportRouter} from './report';
+import {onboardingRouter} from './onboarding';
 import sentryErrorHandler from '../lib/sentry';
 import firebaseBodyParser from '../lib/firebaseBodyParser';
 import languageResolver from './lib/languageResolver';
@@ -21,7 +22,7 @@ app.on('error', localErrorHandler);
 const preAuthRouter = createApiPreAuthRouter();
 preAuthRouter
   .use('/killSwitch', killSwitchRouter.routes())
-  .use('/sessions', sessionsPreAuthRouter.routes());
+  .use('/onboarding', onboardingRouter.routes());
 
 const authRouter = createApiAuthRouter();
 authRouter

--- a/functions/src/api/index.ts
+++ b/functions/src/api/index.ts
@@ -3,7 +3,7 @@ import Koa from 'koa';
 
 import {createApiPreAuthRouter, createApiAuthRouter} from '../lib/routers';
 import {killSwitchRouter} from './killswitch';
-import {sessionsRouter} from './sessions';
+import {sessionsRouter, sessionsPreAuthRouter} from './sessions';
 import {userRouter} from './user';
 import {postsRouter} from './posts';
 import {reportRouter} from './report';
@@ -19,7 +19,9 @@ app.on('error', sentryErrorHandler);
 app.on('error', localErrorHandler);
 
 const preAuthRouter = createApiPreAuthRouter();
-preAuthRouter.use('/killSwitch', killSwitchRouter.routes());
+preAuthRouter
+  .use('/killSwitch', killSwitchRouter.routes())
+  .use('/sessions', sessionsPreAuthRouter.routes());
 
 const authRouter = createApiAuthRouter();
 authRouter

--- a/functions/src/api/onboarding/index.spec.ts
+++ b/functions/src/api/onboarding/index.spec.ts
@@ -1,0 +1,52 @@
+import request from 'supertest';
+
+import {onboardingRouter} from '.';
+import createMockServer from '../lib/createMockServer';
+import {createApiAuthRouter} from '../../lib/routers';
+
+import * as sessionsController from '../../controllers/sessions';
+import {LiveSession} from '../../../../shared/src/types/Session';
+
+jest.mock('../../controllers/sessions');
+const mockGetUpcomingPublicSessions = jest.mocked(
+  sessionsController.getUpcomingPublicSessions,
+);
+
+const router = createApiAuthRouter();
+router.use('/onboarding', onboardingRouter.routes());
+const mockServer = createMockServer(router.routes(), router.allowedMethods());
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+});
+
+afterAll(() => {
+  mockServer.close();
+});
+
+describe('/api/onboarding', () => {
+  describe('GET /sessions', () => {
+    it('should return sessions', async () => {
+      mockGetUpcomingPublicSessions.mockResolvedValueOnce([
+        {
+          id: 'some-session-id',
+        },
+        {
+          id: 'some-other-session-id',
+        },
+      ] as LiveSession[]);
+      const response = await request(mockServer).get('/onboarding/sessions');
+
+      expect(mockGetUpcomingPublicSessions).toHaveBeenCalledTimes(1);
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual([
+        {
+          id: 'some-session-id',
+        },
+        {
+          id: 'some-other-session-id',
+        },
+      ]);
+    });
+  });
+});

--- a/functions/src/api/onboarding/index.spec.ts
+++ b/functions/src/api/onboarding/index.spec.ts
@@ -2,7 +2,7 @@ import request from 'supertest';
 
 import {onboardingRouter} from '.';
 import createMockServer from '../lib/createMockServer';
-import {createApiAuthRouter} from '../../lib/routers';
+import {createApiPreAuthRouter} from '../../lib/routers';
 
 import * as sessionsController from '../../controllers/sessions';
 import {LiveSession} from '../../../../shared/src/types/Session';
@@ -12,7 +12,7 @@ const mockGetUpcomingPublicSessions = jest.mocked(
   sessionsController.getUpcomingPublicSessions,
 );
 
-const router = createApiAuthRouter();
+const router = createApiPreAuthRouter();
 router.use('/onboarding', onboardingRouter.routes());
 const mockServer = createMockServer(router.routes(), router.allowedMethods());
 
@@ -38,6 +38,7 @@ describe('/api/onboarding', () => {
       const response = await request(mockServer).get('/onboarding/sessions');
 
       expect(mockGetUpcomingPublicSessions).toHaveBeenCalledTimes(1);
+      expect(mockGetUpcomingPublicSessions).toHaveBeenCalledWith(undefined);
       expect(response.status).toBe(200);
       expect(response.body).toEqual([
         {
@@ -47,6 +48,14 @@ describe('/api/onboarding', () => {
           id: 'some-other-session-id',
         },
       ]);
+    });
+
+    it('supports limiting the results', async () => {
+      mockGetUpcomingPublicSessions.mockResolvedValueOnce([]);
+      await request(mockServer).get('/onboarding/sessions?limit=4');
+
+      expect(mockGetUpcomingPublicSessions).toHaveBeenCalledTimes(1);
+      expect(mockGetUpcomingPublicSessions).toHaveBeenCalledWith(4);
     });
   });
 });

--- a/functions/src/api/onboarding/index.ts
+++ b/functions/src/api/onboarding/index.ts
@@ -1,14 +1,25 @@
+import * as yup from 'yup';
+import validator from 'koa-yup-validator';
 import {createApiPreAuthRouter} from '../../lib/routers';
 import * as sessionsController from '../../controllers/sessions';
 
 const onboardingRouter = createApiPreAuthRouter();
 
-onboardingRouter.get('/sessions', async ctx => {
-  const {response} = ctx;
-
-  const sessions = await sessionsController.getUpcomingPublicSessions(3);
-  response.status = 200;
-  ctx.body = sessions;
+const SessionsQuerySchema = yup.object({
+  limit: yup.number().positive().integer(),
 });
+
+onboardingRouter.get(
+  '/sessions',
+  validator({query: SessionsQuerySchema}),
+  async ctx => {
+    const {limit} = ctx.state.validated.query;
+
+    const sessions = await sessionsController.getUpcomingPublicSessions(limit);
+
+    ctx.status = 200;
+    ctx.body = sessions;
+  },
+);
 
 export {onboardingRouter};

--- a/functions/src/api/onboarding/index.ts
+++ b/functions/src/api/onboarding/index.ts
@@ -1,0 +1,14 @@
+import {createApiPreAuthRouter} from '../../lib/routers';
+import * as sessionsController from '../../controllers/sessions';
+
+const onboardingRouter = createApiPreAuthRouter();
+
+onboardingRouter.get('/sessions', async ctx => {
+  const {response} = ctx;
+
+  const sessions = await sessionsController.getUpcomingPublicSessions(3);
+  response.status = 200;
+  ctx.body = sessions;
+});
+
+export {onboardingRouter};

--- a/functions/src/api/sessions/index.ts
+++ b/functions/src/api/sessions/index.ts
@@ -3,7 +3,7 @@ import validator from 'koa-yup-validator';
 import 'firebase-functions';
 
 import {SessionType} from '../../../../shared/src/types/Session';
-import {createApiAuthRouter} from '../../lib/routers';
+import {createApiAuthRouter, createApiPreAuthRouter} from '../../lib/routers';
 import restrictAccessToRole from '../lib/restrictAccessToRole';
 
 import * as sessionsController from '../../controllers/sessions';
@@ -19,6 +19,15 @@ import {
 import {RequestError} from '../../controllers/errors/RequestError';
 
 const sessionsRouter = createApiAuthRouter();
+const sessionsPreAuthRouter = createApiPreAuthRouter();
+
+sessionsPreAuthRouter.get('/next', async ctx => {
+  const {response} = ctx;
+
+  const sessions = await sessionsController.getNextPublicSessions(3);
+  response.status = 200;
+  ctx.body = sessions;
+});
 
 sessionsRouter.get('/', async ctx => {
   const {response, user, query} = ctx;
@@ -258,4 +267,4 @@ sessionsRouter.put(
   },
 );
 
-export {sessionsRouter};
+export {sessionsPreAuthRouter, sessionsRouter};

--- a/functions/src/api/sessions/index.ts
+++ b/functions/src/api/sessions/index.ts
@@ -3,7 +3,7 @@ import validator from 'koa-yup-validator';
 import 'firebase-functions';
 
 import {SessionType} from '../../../../shared/src/types/Session';
-import {createApiAuthRouter, createApiPreAuthRouter} from '../../lib/routers';
+import {createApiAuthRouter} from '../../lib/routers';
 import restrictAccessToRole from '../lib/restrictAccessToRole';
 
 import * as sessionsController from '../../controllers/sessions';
@@ -19,22 +19,16 @@ import {
 import {RequestError} from '../../controllers/errors/RequestError';
 
 const sessionsRouter = createApiAuthRouter();
-const sessionsPreAuthRouter = createApiPreAuthRouter();
-
-sessionsPreAuthRouter.get('/next', async ctx => {
-  const {response} = ctx;
-
-  const sessions = await sessionsController.getNextPublicSessions(3);
-  response.status = 200;
-  ctx.body = sessions;
-});
 
 sessionsRouter.get('/', async ctx => {
   const {response, user, query} = ctx;
   const exerciseId =
     typeof query.exerciseId === 'string' ? query.exerciseId : undefined;
 
-  const sessions = await sessionsController.getSessions(user.id, exerciseId);
+  const sessions = await sessionsController.getSessionsByUserId(
+    user.id,
+    exerciseId,
+  );
   response.status = 200;
   ctx.body = sessions;
 });
@@ -267,4 +261,4 @@ sessionsRouter.put(
   },
 );
 
-export {sessionsPreAuthRouter, sessionsRouter};
+export {sessionsRouter};

--- a/functions/src/controllers/sessions.spec.ts
+++ b/functions/src/controllers/sessions.spec.ts
@@ -26,7 +26,8 @@ import {
   removeSession,
   updateSessionState,
   updateSession,
-  getSessions,
+  getSessionsByUserId,
+  getUpcomingPublicSessions,
   getSessionToken,
   updateInterestedCount,
   getSession,
@@ -51,7 +52,9 @@ jest.mock('../models/session');
 jest.mock('../models/user');
 jest.mock('../lib/dailyUtils');
 
-const mockGetSessions = sessionModel.getSessions as jest.Mock;
+const mockGetSessionsByUserId = sessionModel.getSessionsByUserId as jest.Mock;
+const mockGetUpcomingPublicSessions =
+  sessionModel.getUpcomingPublicSessions as jest.Mock;
 const mockAddSession = sessionModel.addSession as jest.Mock;
 const mockGetSessionById = sessionModel.getSessionById as jest.Mock;
 const mockGetSessionStateById = sessionModel.getSessionStateById as jest.Mock;
@@ -76,9 +79,9 @@ beforeEach(async () => {
 });
 
 describe('sessions - controller', () => {
-  describe('getSessions', () => {
+  describe('getSessionsByUserId', () => {
     it('should get sessions with host profile', async () => {
-      mockGetSessions.mockResolvedValueOnce([
+      mockGetSessionsByUserId.mockResolvedValueOnce([
         {
           closingTime: '2022-10-10T10:00:00.000Z',
           hostId: 'some-user-id',
@@ -86,19 +89,19 @@ describe('sessions - controller', () => {
         },
       ]);
 
-      const sessions = await getSessions('all');
+      const sessions = await getSessionsByUserId('all');
 
       expect(sessions).toHaveLength(1);
       expect(sessions[0].hostProfile?.displayName).toEqual('some-name');
       expect(sessions[0].hostProfile?.photoURL).toEqual('some-photo-url');
-      expect(mockGetSessions).toHaveBeenCalledTimes(1);
-      expect(mockGetSessions).toHaveBeenCalledWith('all', undefined);
+      expect(mockGetSessionsByUserId).toHaveBeenCalledTimes(1);
+      expect(mockGetSessionsByUserId).toHaveBeenCalledWith('all', undefined);
       expect(mockGetPublicUserInfo).toHaveBeenCalledTimes(1);
       expect(mockGetPublicUserInfo).toHaveBeenCalledWith('some-user-id');
     });
 
     it('should get public sessions by exerciseId with host profile', async () => {
-      mockGetSessions.mockResolvedValueOnce([
+      mockGetSessionsByUserId.mockResolvedValueOnce([
         {
           closingTime: '2022-10-10T10:00:00.000Z',
           hostId: 'some-user-id',
@@ -106,13 +109,16 @@ describe('sessions - controller', () => {
         },
       ]);
 
-      const sessions = await getSessions('some-user-id', 'some-exercise-id');
+      const sessions = await getSessionsByUserId(
+        'some-user-id',
+        'some-exercise-id',
+      );
 
       expect(sessions).toHaveLength(1);
       expect(sessions[0].hostProfile?.displayName).toEqual('some-name');
       expect(sessions[0].hostProfile?.photoURL).toEqual('some-photo-url');
-      expect(mockGetSessions).toHaveBeenCalledTimes(1);
-      expect(mockGetSessions).toHaveBeenCalledWith(
+      expect(mockGetSessionsByUserId).toHaveBeenCalledTimes(1);
+      expect(mockGetSessionsByUserId).toHaveBeenCalledWith(
         'some-user-id',
         'some-exercise-id',
       );
@@ -121,7 +127,7 @@ describe('sessions - controller', () => {
     });
 
     it('should filter out sessions that have been closed', async () => {
-      mockGetSessions.mockResolvedValueOnce([
+      mockGetSessionsByUserId.mockResolvedValueOnce([
         {
           closingTime: '2022-10-10T09:00:00.000Z',
           hostId: 'some-user-id',
@@ -129,13 +135,13 @@ describe('sessions - controller', () => {
         },
       ]);
 
-      const sessions = await getSessions('all');
+      const sessions = await getSessionsByUserId('all');
 
       expect(sessions).toHaveLength(0);
     });
 
     it('should include closed sessions containing userid (aka user has joined)', async () => {
-      mockGetSessions.mockResolvedValueOnce([
+      mockGetSessionsByUserId.mockResolvedValueOnce([
         {
           closingTime: '2022-10-10T09:00:00.000Z',
           hostId: 'other-user-id',
@@ -143,7 +149,7 @@ describe('sessions - controller', () => {
         },
       ]);
 
-      const sessions = await getSessions('some-user-id');
+      const sessions = await getSessionsByUserId('some-user-id');
 
       expect(sessions).toHaveLength(1);
       expect(sessions).toEqual([
@@ -157,7 +163,7 @@ describe('sessions - controller', () => {
     });
 
     it('should include closed sessions which userid is the host', async () => {
-      mockGetSessions.mockResolvedValueOnce([
+      mockGetSessionsByUserId.mockResolvedValueOnce([
         {
           closingTime: '2022-10-10T09:00:00.000Z',
           hostId: 'host-user-id',
@@ -165,7 +171,7 @@ describe('sessions - controller', () => {
         },
       ]);
 
-      const sessions = await getSessions('host-user-id');
+      const sessions = await getSessionsByUserId('host-user-id');
 
       expect(sessions).toHaveLength(1);
       expect(sessions).toEqual([
@@ -176,6 +182,37 @@ describe('sessions - controller', () => {
           userIds: ['*'],
         },
       ]);
+    });
+  });
+
+  describe('getUpcomingPublicSessions', () => {
+    it('should get sessions with host profile', async () => {
+      mockGetUpcomingPublicSessions.mockResolvedValueOnce([
+        {
+          closingTime: '2022-10-10T10:00:00.000Z',
+          hostId: 'some-user-id',
+          userIds: ['*'],
+        },
+      ]);
+
+      const sessions = await getUpcomingPublicSessions();
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].hostProfile?.displayName).toEqual('some-name');
+      expect(sessions[0].hostProfile?.photoURL).toEqual('some-photo-url');
+      expect(mockGetUpcomingPublicSessions).toHaveBeenCalledTimes(1);
+      expect(mockGetUpcomingPublicSessions).toHaveBeenCalledWith(undefined);
+      expect(mockGetPublicUserInfo).toHaveBeenCalledTimes(1);
+      expect(mockGetPublicUserInfo).toHaveBeenCalledWith('some-user-id');
+    });
+
+    it('supports limiting the query', async () => {
+      mockGetUpcomingPublicSessions.mockResolvedValueOnce([]);
+
+      await getUpcomingPublicSessions(4);
+
+      expect(mockGetUpcomingPublicSessions).toHaveBeenCalledTimes(1);
+      expect(mockGetUpcomingPublicSessions).toHaveBeenCalledWith(4);
     });
   });
 

--- a/functions/src/controllers/sessions.ts
+++ b/functions/src/controllers/sessions.ts
@@ -36,13 +36,19 @@ export const getSessions = async (
   userId: string,
   exerciseId?: string,
 ): Promise<LiveSession[]> => {
-  const sessions = await (exerciseId
-    ? sessionModel.getPublicSessionsByExerciseId(userId, exerciseId)
-    : sessionModel.getSessions(userId));
+  const sessions = await sessionModel.getSessions(userId, exerciseId);
 
   return Promise.all(
     sessions.filter(s => isUserAllowedToJoin(s, userId)).map(mapSession),
   );
+};
+
+export const getNextPublicSessions = async (
+  limit?: number,
+): Promise<LiveSession[]> => {
+  const sessions = await sessionModel.getSessions(undefined, undefined, limit);
+
+  return Promise.all(sessions.map(mapSession));
 };
 
 export const getSessionToken = async (

--- a/functions/src/controllers/sessions.ts
+++ b/functions/src/controllers/sessions.ts
@@ -32,21 +32,21 @@ const isUserAllowedToJoin = (session: LiveSession, userId: string) =>
   session.userIds.includes(userId) ||
   session.hostId === userId;
 
-export const getSessions = async (
+export const getSessionsByUserId = async (
   userId: string,
   exerciseId?: string,
 ): Promise<LiveSession[]> => {
-  const sessions = await sessionModel.getSessions(userId, exerciseId);
+  const sessions = await sessionModel.getSessionsByUserId(userId, exerciseId);
 
   return Promise.all(
     sessions.filter(s => isUserAllowedToJoin(s, userId)).map(mapSession),
   );
 };
 
-export const getNextPublicSessions = async (
+export const getUpcomingPublicSessions = async (
   limit?: number,
 ): Promise<LiveSession[]> => {
-  const sessions = await sessionModel.getSessions(undefined, undefined, limit);
+  const sessions = await sessionModel.getUpcomingPublicSessions(limit);
 
   return Promise.all(sessions.map(mapSession));
 };

--- a/functions/src/models/session.ts
+++ b/functions/src/models/session.ts
@@ -90,32 +90,28 @@ export const getSessionByInviteCode = async ({
   return getSession(getData<LiveSessionData>(result.docs[0]));
 };
 
-export const getSessions = async (userId: string) => {
-  const sessionsCollection = firestore().collection(SESSIONS_COLLECTION);
-  const snapshot = await sessionsCollection
-    .where('ended', '==', false)
-    .where('userIds', 'array-contains-any', ['*', userId])
-    .orderBy('closingTime')
-    .where('closingTime', '>', sessionClosingRange())
-    .orderBy('startTime', 'asc')
-    .get();
-
-  return snapshot.docs.map(doc => getSession(getData<LiveSessionData>(doc)));
-};
-
-export const getPublicSessionsByExerciseId = async (
-  userId: string,
-  exerciseId: string,
+export const getSessions = async (
+  userId?: string,
+  exerciseId?: string,
+  limit?: number,
 ) => {
-  const sessionsCollection = firestore().collection(SESSIONS_COLLECTION);
-  const snapshot = await sessionsCollection
+  let query = firestore()
+    .collection(SESSIONS_COLLECTION)
+    .where('userIds', 'array-contains-any', userId ? ['*', userId] : ['*'])
     .where('ended', '==', false)
-    .where('exerciseId', '==', exerciseId)
-    .where('userIds', 'array-contains-any', ['*', userId])
     .orderBy('closingTime')
     .where('closingTime', '>', sessionClosingRange())
-    .orderBy('startTime', 'asc')
-    .get();
+    .orderBy('startTime', 'asc');
+
+  if (exerciseId) {
+    query = query.where('exerciseId', '==', exerciseId);
+  }
+
+  if (limit) {
+    query = query.limit(limit);
+  }
+
+  const snapshot = await query.get();
 
   return snapshot.docs.map(doc => getSession(getData<LiveSessionData>(doc)));
 };


### PR DESCRIPTION
In preparation for the onboarding. This adds a non authorised route for fetching the closest upcoming, public sessions `/api/onboarding/sessions`