### PR TITLE
Fix pre-selected exercise create session flow

### DIFF
--- a/client/src/lib/components/Cards/SessionCard/ExerciseCardContainer.tsx
+++ b/client/src/lib/components/Cards/SessionCard/ExerciseCardContainer.tsx
@@ -27,7 +27,7 @@ const ExerciseCardContainer: React.FC<ExerciseCardContainerProps> = ({
   }, [exercise]);
 
   const onPress = useCallback(() => {
-    navigate('CreateSessionModal', {exerciseId: exercise.id, discover: true});
+    navigate('CreateSessionModal', {exerciseId: exercise.id});
   }, [exercise, navigate]);
 
   if (!exercise) {

--- a/client/src/lib/navigation/ModalStack.tsx
+++ b/client/src/lib/navigation/ModalStack.tsx
@@ -164,7 +164,7 @@ const ModalStack = () => {
           name={'CreateSessionModal'}
           component={CreateSessionModal}
           options={props =>
-            props.route.params.discover
+            props.route.params.exerciseId
               ? fullSheetModalScreenOptions
               : sheetModalScreenOptions
           }

--- a/client/src/lib/navigation/constants/routes.ts
+++ b/client/src/lib/navigation/constants/routes.ts
@@ -68,7 +68,7 @@ export type ModalStackProps = {
   };
   SessionUnavailableModal: undefined;
   AddSessionByInviteModal?: {inviteCode?: number};
-  CreateSessionModal: {exerciseId?: Exercise['id']; discover?: boolean};
+  CreateSessionModal: {exerciseId?: Exercise['id']};
   UpgradeAccountModal?: undefined;
   RequestPublicHostModal?: {code?: string; haveRequested?: boolean};
   ChangeLanguageModal: undefined;

--- a/client/src/routes/modals/CompletedSessionModal/CompletedSessionModal.tsx
+++ b/client/src/routes/modals/CompletedSessionModal/CompletedSessionModal.tsx
@@ -91,7 +91,9 @@ const CompletedSessionModal = () => {
 
   const onStartSession = useCallback(() => {
     popToTop();
-    navigate('CreateSessionModal', {exerciseId: payload.exerciseId});
+    navigate('CreateSessionModal', {
+      exerciseId: payload.exerciseId,
+    });
   }, [payload, navigate, popToTop]);
 
   const exercise = useExerciseById(payload.exerciseId);

--- a/client/src/routes/modals/CreateSessionModal/CreateSessionModal.tsx
+++ b/client/src/routes/modals/CreateSessionModal/CreateSessionModal.tsx
@@ -66,7 +66,7 @@ const steps = ({
 
 const CreateSessionModal = () => {
   const {
-    params: {exerciseId, discover},
+    params: {exerciseId},
   } = useRoute<RouteProp<ModalStackProps, 'CreateSessionModal'>>();
   const [currentStep, setCurrentStep] = useState(0);
   const [selectedExercise, setSelectedExercise] = useState<
@@ -140,7 +140,6 @@ const CreateSessionModal = () => {
           <Fade visible={false} key={currentStep - 1}>
             <PreviousStepComponent
               selectedExercise={selectedExercise}
-              discover={discover}
               setSelectedExercise={setSelectedExercise}
               selectedModeAndType={selectedModeAndType}
               setSelectedModeAndType={setSelectedModeAndType}
@@ -155,7 +154,6 @@ const CreateSessionModal = () => {
         <Fade visible={true} key={currentStep}>
           <CurrentStepComponent
             selectedExercise={selectedExercise}
-            discover={discover}
             setSelectedExercise={setSelectedExercise}
             selectedModeAndType={selectedModeAndType}
             setSelectedModeAndType={setSelectedModeAndType}
@@ -170,7 +168,6 @@ const CreateSessionModal = () => {
           <Fade visible={false} key={currentStep + 1}>
             <NextStepComponent
               selectedExercise={selectedExercise}
-              discover={discover}
               setSelectedExercise={setSelectedExercise}
               selectedModeAndType={selectedModeAndType}
               setSelectedModeAndType={setSelectedModeAndType}

--- a/client/src/routes/modals/CreateSessionModal/components/steps/SelectTypeStep.tsx
+++ b/client/src/routes/modals/CreateSessionModal/components/steps/SelectTypeStep.tsx
@@ -123,7 +123,6 @@ const SelectTypeStep: React.FC<StepProps> = ({
   nextStep,
   isPublicHost,
   selectedExercise,
-  discover,
 }) => {
   const {t} = useTranslation('Modal.CreateSession');
   const {navigate, popToTop} =
@@ -134,14 +133,14 @@ const SelectTypeStep: React.FC<StepProps> = ({
   const [isLoadingSessions, setIsLoadingSessions] = useState(false);
 
   useEffect(() => {
-    if (discover && selectedExercise) {
+    if (selectedExercise) {
       setIsLoadingSessions(true);
       fetchSessions(selectedExercise).then(loadedSessions => {
         setSessions(loadedSessions);
         setIsLoadingSessions(false);
       });
     }
-  }, [setSessions, setIsLoadingSessions, selectedExercise, discover]);
+  }, [setSessions, setIsLoadingSessions, selectedExercise]);
 
   const exercise = useMemo(
     () => (selectedExercise ? getExerciseById(selectedExercise) : null),
@@ -233,7 +232,7 @@ const SelectTypeStep: React.FC<StepProps> = ({
     [exercise, isPublicHost, onTypePress, t],
   );
 
-  if (discover && exercise) {
+  if (exercise) {
     return (
       <>
         <BottomSheetFlatList


### PR DESCRIPTION
Issue: [Notion Task](https://www.notion.so/29k/Early-Access-2794500652b34c64b0aff0dbbc53e0ab?pvs=4#92e59cb4f5eb4989bc419cbc6f818970)

### Description of the Change

We want to show the exercise icon and existing sessions on that exercise whenever we specify a "pre-selected" exercise when going into the "create session flow". 

e.g

<img src="https://user-images.githubusercontent.com/7523828/229822825-a39776bf-e81a-437c-8eb4-3d49c746a7bb.png" width="300" />
