### PR TITLE
Fix unresponsive screen on going back

### DIFF
--- a/client/src/lib/navigation/OverlayStack.tsx
+++ b/client/src/lib/navigation/OverlayStack.tsx
@@ -16,6 +16,7 @@ const {Navigator, Screen} = createStackNavigator<OverlayStackProps>();
 const screenOptions: StackNavigationOptions = {
   headerShown: false,
   presentation: 'modal',
+  detachPreviousScreen: false, // Fixes issue with previous screen becoming unresponsive
   cardStyle: Platform.select({
     ios: {
       borderTopLeftRadius: SETTINGS.BORDER_RADIUS.CARDS,


### PR DESCRIPTION
Fix issue where screen becomes unresponsive when going back from an overlay, e.g. About