### PR TITLE
Re-usable Node component in SessionCompletedModal

### DIFF
--- a/client/src/lib/components/Node/Node.tsx
+++ b/client/src/lib/components/Node/Node.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import styled from 'styled-components/native';
+import {COLORS} from '../../../../../shared/src/constants/colors';
+
+type NodeProps = {
+  size?: number;
+};
+
+const Ring = styled.View<NodeProps>(({size = 22}) => ({
+  height: size,
+  width: size,
+  border: 1,
+  borderRadius: size / 2,
+  backgroundColor: COLORS.WHITE,
+  alignItems: 'center',
+  justifyContent: 'center',
+}));
+
+const Dot = styled.View<NodeProps>(({size = 14}) => ({
+  height: size,
+  width: size,
+  borderRadius: size / 2,
+  backgroundColor: COLORS.MEDIUM_GREEN,
+}));
+
+const Node: React.FC<NodeProps> = ({size = 22}) => (
+  <Ring size={size}>
+    <Dot size={size * 0.636} />
+  </Ring>
+);
+
+export default Node;

--- a/client/src/routes/modals/CompletedSessionModal/CompletedSessionModal.tsx
+++ b/client/src/routes/modals/CompletedSessionModal/CompletedSessionModal.tsx
@@ -24,7 +24,6 @@ import {formatExerciseName} from '../../../lib/utils/string';
 import {COLORS} from '../../../../../shared/src/constants/colors';
 import Markdown from '../../../lib/components/Typography/Markdown/Markdown';
 import Byline from '../../../lib/components/Bylines/Byline';
-import {CheckIcon} from '../../../lib/components/Icons/Check/Check';
 import {Body14} from '../../../lib/components/Typography/Body/Body';
 import Badge from '../../../lib/components/Badge/Badge';
 import {
@@ -47,6 +46,7 @@ import TouchableOpacity from '../../../lib/components/TouchableOpacity/Touchable
 import useGetFeedbackBySessionId from '../../../lib/user/hooks/useGetFeedbackBySessionId';
 import FeedbackThumb from './components/FeedbackThumb';
 import FeedbackComment from './components/FeedbackComment';
+import Node from '../../../lib/components/Node/Node';
 
 const Content = styled(Gutters)({
   justifyContent: 'space-between',
@@ -75,11 +75,6 @@ const ImageContainer = styled(Image)({
   aspectRatio: '1',
   flex: 1,
   height: 90,
-});
-
-const CheckIconWrapper = styled(View)({
-  width: 22,
-  height: 22,
 });
 
 const SharingPost = styled(MyPostCard)({
@@ -191,9 +186,8 @@ const CompletedSessionModal = () => {
         <Spacer16 />
         <StatusRow>
           <VerticalAlign>
-            <CheckIconWrapper>
-              <CheckIcon fill={COLORS.PRIMARY} />
-            </CheckIconWrapper>
+            <Node />
+            <Spacer4 />
             <Body14>{t('completed')}</Body14>
             <Spacer4 />
             <Badge

--- a/client/src/routes/screens/Journey/components/JourneyNode.tsx
+++ b/client/src/routes/screens/Journey/components/JourneyNode.tsx
@@ -27,6 +27,7 @@ import {SPACINGS} from '../../../../lib/constants/spacings';
 import useExerciseById from '../../../../lib/content/hooks/useExerciseById';
 import {ModalStackProps} from '../../../../lib/navigation/constants/routes';
 import useUserProfile from '../../../../lib/user/hooks/useUserProfile';
+import Node from '../../../../lib/components/Node/Node';
 
 const FULL_HEIGHT = 110;
 const NODE_SIZE = 22;
@@ -43,7 +44,6 @@ const Lottie = styled(AnimatedLottieView)({
 const Container = styled(TouchableOpacity)({
   flexDirection: 'row',
   height: FULL_HEIGHT,
-  marginLeft: NODE_SIZE / 2,
 });
 
 const ContentContainer = styled.View({
@@ -51,31 +51,13 @@ const ContentContainer = styled.View({
   flex: 1,
 });
 
-const Node = styled.View({
-  marginLeft: -(NODE_SIZE / 2),
-  height: NODE_SIZE,
-  width: NODE_SIZE,
-  border: 1,
-  borderRadius: NODE_SIZE / 2,
-  backgroundColor: COLORS.WHITE,
-  alignItems: 'center',
-  justifyContent: 'center',
-});
-
 const Line = styled.View<Pick<JourneyNodeProps, 'isLast'>>(({isLast}) => ({
-  height: isLast ? 0 : FULL_HEIGHT,
-  width: 1,
-  backgroundColor: COLORS.BLACK,
   position: 'absolute',
-  left: -1,
+  left: NODE_SIZE / 2,
+  width: 1,
+  height: isLast ? 0 : FULL_HEIGHT,
+  backgroundColor: COLORS.BLACK,
 }));
-
-const InnerNode = styled.View({
-  height: 14,
-  width: 14,
-  borderRadius: 14 / 2,
-  backgroundColor: COLORS.MEDIUM_GREEN,
-});
 
 const Row = styled.View({
   flexDirection: 'row',
@@ -137,9 +119,7 @@ const JourneyNode: React.FC<JourneyNodeProps> = ({
   return (
     <Container onPress={openCompleteSessionModal}>
       <Line isLast={isLast} />
-      <Node>
-        <InnerNode />
-      </Node>
+      <Node size={NODE_SIZE} />
       <ContentContainer>
         <Row>
           <Column>


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="492" alt="image" src="https://user-images.githubusercontent.com/474066/234387872-dd28e740-6065-4f2e-b09b-eb81c0cc2cbe.png"> | <img width="492" alt="image" src="https://user-images.githubusercontent.com/474066/234387810-e51b36b3-d2d6-4822-93b2-62b9294015ac.png"> |
