### PR TITLE
Don't wait for end video in async sessions

### DIFF
--- a/client/src/lib/session/components/IntroPortal/IntroPortal.tsx
+++ b/client/src/lib/session/components/IntroPortal/IntroPortal.tsx
@@ -75,10 +75,14 @@ const IntroPortal: React.FC<IntroPortalProps> = ({
     if (sessionState?.started && !introPortal?.videoLoop?.source) {
       // If no video is defined, navigate directly
       onNavigateToSession();
+    } else if (sessionState?.started && !isLive) {
+      // If async, don't wait for the end video
+      onNavigateToSession();
     }
   }, [
     sessionState?.started,
     introPortal?.videoLoop?.source,
+    isLive,
     onNavigateToSession,
   ]);
 


### PR DESCRIPTION
As discussed waiting for the end video in an async sessions doesn't make that much sense
