### PR TITLE
Group sessions by relative dates

### DIFF
--- a/client/src/lib/date/hooks/useGetRelativeDateGroup.ts
+++ b/client/src/lib/date/hooks/useGetRelativeDateGroup.ts
@@ -1,0 +1,29 @@
+import dayjs, {Dayjs} from 'dayjs';
+import {useCallback} from 'react';
+import {useTranslation} from 'react-i18next';
+
+const useGetRelativeDateGroup = () => {
+  const {t} = useTranslation('Component.RelativeDateGroup');
+
+  return useCallback(
+    (date: Dayjs) => {
+      if (date.isToday()) {
+        return t('today');
+      }
+      if (date.isTomorrow()) {
+        return t('tomorrow');
+      }
+      if (date.isoWeek() === dayjs().isoWeek()) {
+        return t('thisWeek');
+      }
+      if (date.isoWeek() === dayjs().add(1, 'week').isoWeek()) {
+        return t('nextWeek');
+      }
+
+      return t('upcoming');
+    },
+    [t],
+  );
+};
+
+export default useGetRelativeDateGroup;

--- a/client/src/lib/i18n/index.ts
+++ b/client/src/lib/i18n/index.ts
@@ -11,6 +11,9 @@ import 'dayjs/locale/pt';
 import 'dayjs/locale/sv';
 import 'dayjs/locale/es';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
+import isToday from 'dayjs/plugin/isToday';
+import isTomorrow from 'dayjs/plugin/isTomorrow';
+import isoWeek from 'dayjs/plugin/isoWeek';
 
 import content from '../../../../content/content.json';
 import {
@@ -24,6 +27,9 @@ import {omitExercisesAndCollections} from './utils/utils';
 export * from '../../../../shared/src/constants/i18n';
 
 dayjs.extend(localizedFormat);
+dayjs.extend(isToday);
+dayjs.extend(isTomorrow);
+dayjs.extend(isoWeek);
 
 const DEFAULT_24HOUR_LANGUAGE_TAG = 'en-gb';
 

--- a/client/src/routes/screens/Home/Home.tsx
+++ b/client/src/routes/screens/Home/Home.tsx
@@ -1,3 +1,5 @@
+import {groupBy} from 'ramda';
+import dayjs from 'dayjs';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {RefreshControl, SectionList} from 'react-native';
 import {useTranslation} from 'react-i18next';
@@ -34,6 +36,7 @@ import StickyHeading from '../../../lib/components/StickyHeading/StickyHeading';
 import TopBar from '../../../lib/components/TopBar/TopBar';
 import MiniProfile from '../../../lib/components/MiniProfile/MiniProfile';
 import BottomFade from '../../../lib/components/BottomFade/BottomFade';
+import useGetRelativeDateGroup from '../../../lib/date/hooks/useGetRelativeDateGroup';
 
 type Section = {
   title: string;
@@ -105,6 +108,7 @@ const Home = () => {
     useNavigation<NativeStackNavigationProp<OverlayStackProps>>();
   const {fetchSessions, sessions, pinnedSessions, hostedSessions} =
     useSessions();
+  const getRelativeDateGroup = useGetRelativeDateGroup();
   const listRef = useRef<SectionList<LiveSessionType, Section>>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -127,14 +131,21 @@ const Home = () => {
       });
     }
     if (sessions.length > 0) {
-      sectionsList.push({
-        title: t('sections.comming'),
-        data: sessions,
-        type: 'comming',
+      Object.entries(
+        groupBy(
+          session => getRelativeDateGroup(dayjs(session.startTime)),
+          sessions,
+        ),
+      ).forEach(([group, items]) => {
+        sectionsList.push({
+          title: group,
+          data: items,
+          type: 'comming',
+        });
       });
     }
     return sectionsList;
-  }, [sessions, pinnedSessions, hostedSessions, t]);
+  }, [sessions, pinnedSessions, hostedSessions, t, getRelativeDateGroup]);
 
   useEffect(() => {
     fetchSessions();

--- a/content/src/ui/Component.RelativeDateGroup.json
+++ b/content/src/ui/Component.RelativeDateGroup.json
@@ -1,0 +1,12 @@
+{
+  "en": {
+    "today": "Today",
+    "tomorrow": "Tomorrow",
+    "thisWeek": "This week",
+    "nextWeek": "Next week",
+    "upcoming": "Upcoming"
+  },
+  "sv": {},
+  "pt": {},
+  "es": {}
+}


### PR DESCRIPTION
[Task in notion](https://www.notion.so/29k/Early-Access-2794500652b34c64b0aff0dbbc53e0ab?pvs=4#5c50a0a81171477f9e3ca731f45a3509)

Groups sessions by:
* Today
* Tomorrow
* This week
* Next week
* Upcoming

<img width="492" alt="image" src="https://user-images.githubusercontent.com/474066/236133915-0380306f-ad29-4121-9992-e00923806aba.png">
