### PR TITLE
Do not send undefined bundle version

### DIFF
--- a/client/src/lib/killSwitch/hooks/useKillSwitch.ts
+++ b/client/src/lib/killSwitch/hooks/useKillSwitch.ts
@@ -28,7 +28,7 @@ const getKillSwitchUrl = ({
     `platform=${os}`,
     `platformVersion=${osVersion}`,
     `version=${nativeVersion}`,
-    `bundleVersion=${bundleVersion}`,
+    `bundleVersion=${bundleVersion ?? ''}`,
   ].join('&');
 
 const useKillSwitch = () => {


### PR DESCRIPTION
This forced all new installs (without a bundle version) to download latest version