### PR TITLE
Check in client that session is still open

### DIFF
--- a/client/src/lib/session/hooks/useIsAllowedToJoin.spec.ts
+++ b/client/src/lib/session/hooks/useIsAllowedToJoin.spec.ts
@@ -1,0 +1,144 @@
+import {useNavigation} from '@react-navigation/native';
+import {renderHook} from '@testing-library/react-hooks';
+import {FirebaseAuthTypes} from '@react-native-firebase/auth';
+
+import {getSession} from '../../sessions/api/session';
+import useSessions from '../../sessions/hooks/useSessions';
+import {LiveSessionType} from '../../../../../shared/src/schemas/Session';
+import useUserState from '../../user/state/state';
+import useIsAllowedToJoin from './useIsAllowedToJoin';
+import useSessionState from '../state/state';
+
+jest.mock('../../sessions/api/session');
+jest.mock('../../sessions/hooks/useSessions');
+
+const mockGetSession = jest.mocked(getSession);
+const mockUseSession = jest.mocked(useSessions);
+
+afterEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers().useRealTimers();
+});
+
+describe('useIsAllowedToJoin', () => {
+  const navigation = useNavigation();
+  const mockNavigate = jest.mocked(navigation.navigate);
+  const mockFetchSessions = jest.fn();
+  mockUseSession.mockReturnValue({
+    fetchSessions: mockFetchSessions,
+  } as any);
+
+  it('should be allowed to when closing time is not passed', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-05-16T10:00:00Z'));
+    useUserState.setState({
+      user: {uid: 'some-user-id'} as FirebaseAuthTypes.User,
+    });
+    mockGetSession.mockResolvedValueOnce({
+      closingTime: '2023-05-16T10:05:00Z',
+      userIds: ['*'],
+      hostId: 'some-host-id',
+    } as LiveSessionType);
+
+    const {result} = renderHook(() => useIsAllowedToJoin());
+
+    const res = await result.current('some-session-id');
+
+    expect(res).toBe(true);
+    expect(mockGetSession).toHaveBeenCalledWith('some-session-id');
+    expect(mockNavigate).toHaveBeenCalledTimes(0);
+    expect(mockFetchSessions).toHaveBeenCalledTimes(0);
+  });
+
+  it('should be allowed to when user is host', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-05-16T10:00:00Z'));
+    useUserState.setState({
+      user: {uid: 'some-host-id'} as FirebaseAuthTypes.User,
+    });
+    mockGetSession.mockResolvedValueOnce({
+      closingTime: '2023-05-16T09:55:00Z',
+      userIds: ['*'],
+      hostId: 'some-host-id',
+    } as LiveSessionType);
+
+    const {result} = renderHook(() => useIsAllowedToJoin());
+
+    const res = await result.current('some-session-id');
+
+    expect(res).toBe(true);
+    expect(mockGetSession).toHaveBeenCalledWith('some-session-id');
+    expect(mockNavigate).toHaveBeenCalledTimes(0);
+    expect(mockFetchSessions).toHaveBeenCalledTimes(0);
+  });
+
+  it('should be allowed to when user is among userIds', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-05-16T10:00:00Z'));
+    useUserState.setState({
+      user: {uid: 'some-user-id'} as FirebaseAuthTypes.User,
+    });
+    mockGetSession.mockResolvedValueOnce({
+      closingTime: '2023-05-16T09:55:00Z',
+      userIds: ['*', 'some-user-id'],
+      hostId: 'some-host-id',
+    } as LiveSessionType);
+
+    const {result} = renderHook(() => useIsAllowedToJoin());
+
+    const res = await result.current('some-session-id');
+
+    expect(res).toBe(true);
+    expect(mockGetSession).toHaveBeenCalledWith('some-session-id');
+    expect(mockNavigate).toHaveBeenCalledTimes(0);
+    expect(mockFetchSessions).toHaveBeenCalledTimes(0);
+  });
+
+  const useTestHook = () => {
+    const isAllowedToJoin = useIsAllowedToJoin();
+    const sessionState = useSessionState(state => state);
+
+    return {isAllowedToJoin, sessionState};
+  };
+  it('should not be allowed to when closingTime has passed', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-05-16T10:00:00Z'));
+    useUserState.setState({
+      user: {uid: 'some-user-id'} as FirebaseAuthTypes.User,
+    });
+    useSessionState.setState({
+      liveSession: {id: 'some-sesssion-id'} as LiveSessionType,
+    });
+    mockGetSession.mockResolvedValueOnce({
+      closingTime: '2023-05-16T09:55:00Z',
+      userIds: ['*'],
+      hostId: 'some-host-id',
+    } as LiveSessionType);
+
+    const {result} = renderHook(() => useTestHook());
+
+    const res = await result.current.isAllowedToJoin('some-session-id');
+
+    expect(res).toBe(false);
+    expect(mockGetSession).toHaveBeenCalledWith('some-session-id');
+    expect(mockNavigate).toHaveBeenCalledTimes(2);
+    expect(mockFetchSessions).toHaveBeenCalledTimes(1);
+    expect(result.current.sessionState.liveSession).toBe(null);
+  });
+
+  it('should not be allowed to when session could not be fetched', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-05-16T10:00:00Z'));
+    useUserState.setState({
+      user: {uid: 'some-user-id'} as FirebaseAuthTypes.User,
+    });
+    mockGetSession.mockRejectedValueOnce(null);
+
+    const {result} = renderHook(() => useTestHook());
+
+    try {
+      const res = await result.current.isAllowedToJoin('some-session-id');
+      expect(res).toBe(false);
+    } catch (error) {}
+
+    expect(mockGetSession).toHaveBeenCalledWith('some-session-id');
+    expect(mockNavigate).toHaveBeenCalledTimes(2);
+    expect(mockFetchSessions).toHaveBeenCalledTimes(1);
+    expect(result.current.sessionState.liveSession).toBe(null);
+  });
+});

--- a/client/src/lib/session/hooks/useIsAllowedToJoin.ts
+++ b/client/src/lib/session/hooks/useIsAllowedToJoin.ts
@@ -1,0 +1,59 @@
+import dayjs from 'dayjs';
+import {LiveSessionType} from '../../../../../shared/src/schemas/Session';
+import useSessionState from '../state/state';
+import useSessions from '../../sessions/hooks/useSessions';
+import {useNavigation} from '@react-navigation/native';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import {
+  ModalStackProps,
+  TabNavigatorProps,
+} from '../../navigation/constants/routes';
+import {useCallback} from 'react';
+import {getSession} from '../../sessions/api/session';
+import useUser from '../../user/hooks/useUser';
+
+const isSessionOpen = (session: LiveSessionType): boolean =>
+  dayjs(session.closingTime).isAfter(dayjs());
+
+const isUserAllowedToJoin = (session: LiveSessionType, userId: string) =>
+  isSessionOpen(session) ||
+  session.userIds.includes(userId) ||
+  session.hostId === userId;
+
+const useIsAllowedToJoin = () => {
+  const user = useUser();
+  const reset = useSessionState(state => state.reset);
+  const {fetchSessions} = useSessions();
+  const {navigate} =
+    useNavigation<
+      NativeStackNavigationProp<TabNavigatorProps & ModalStackProps>
+    >();
+
+  const resetSession = useCallback(() => {
+    reset();
+    fetchSessions();
+    navigate('HomeStack');
+    navigate('SessionUnavailableModal');
+  }, [reset, fetchSessions, navigate]);
+
+  return useCallback(
+    async (sessionId: string) => {
+      try {
+        const session = await getSession(sessionId);
+
+        if (user?.uid && !isUserAllowedToJoin(session, user?.uid)) {
+          resetSession();
+
+          return false;
+        }
+        return true;
+      } catch (error) {
+        resetSession();
+        throw error;
+      }
+    },
+    [user?.uid, resetSession],
+  );
+};
+
+export default useIsAllowedToJoin;


### PR DESCRIPTION
Found this the least intrusive way. The user still have to wait for the pre-join round trip, so might as well check here
