### PR TITLE
Fix error handling on host session invite

### DIFF
--- a/client/src/routes/modals/HostSessionByInviteModal/HostSessionByInviteModal.tsx
+++ b/client/src/routes/modals/HostSessionByInviteModal/HostSessionByInviteModal.tsx
@@ -189,7 +189,7 @@ const HostSessionByInviteModal = () => {
       const fetchedSession = await getSessionByHostingCode(hostingCode);
       setSession(fetchedSession);
     } catch (err) {
-      setError(err as string);
+      setError((err as Error).message as JoinSessionError);
     }
   }, [hostingCode]);
 

--- a/functions/src/api/sessions/index.spec.ts
+++ b/functions/src/api/sessions/index.spec.ts
@@ -555,15 +555,25 @@ describe('/api/sessions', () => {
       mockGetSessionByHostingCode.mockRejectedValueOnce(
         new RequestError(JoinSessionError.notFound),
       );
-      mockGetSessionByHostingCode.mockRejectedValueOnce(
-        new RequestError(JoinSessionError.notFound),
-      );
 
       const response = await request(mockServer).get(
         '/sessions/hostingCode/123456',
       );
       expect(response.text).toEqual(JoinSessionError.notFound);
       expect(response.status).toBe(404);
+    });
+
+    it('should return 401 if session is not available', async () => {
+      getMockCustomClaims.mockReturnValueOnce({role: ROLE.publicHost});
+      mockGetSessionByHostingCode.mockRejectedValueOnce(
+        new RequestError(JoinSessionError.notAvailable),
+      );
+
+      const response = await request(mockServer).get(
+        '/sessions/hostingCode/123456',
+      );
+      expect(response.text).toEqual(JoinSessionError.notAvailable);
+      expect(response.status).toBe(410);
     });
   });
 


### PR DESCRIPTION
Since I wasn't using `err.message` it always defaulted to saying that the user doesn't have public host permission.