### PR TITLE
Temp fix for ExoPlayer duration bug

### DIFF
--- a/client/src/lib/components/MediaControls/MediaControls.tsx
+++ b/client/src/lib/components/MediaControls/MediaControls.tsx
@@ -92,39 +92,58 @@ const MediaControls: React.FC<MediaControlsProps> = ({
 
   const variant = light ? 'secondary' : 'tertiary';
 
+  // Exoplayer in android have issues with sending correct duration for mp3
+  // https://github.com/google/ExoPlayer/issues/7314
+  // A temporary fix is to not show erronius progress and disable skip buttons when
+  // that happens.
+  const durationValid = duration > 0;
+
   return (
     <View>
-      <ProgressWrapper>
-        <Progress color={theme?.textColor} index={time} length={duration} />
-      </ProgressWrapper>
-      <Spacer8 />
-      <TimeWrapper>
-        <TimeLabel color={theme?.textColor}>{displayTime}</TimeLabel>
-        <TimeLabel color={theme?.textColor}>{displayLeft}</TimeLabel>
-      </TimeWrapper>
-      <Spacer16 />
+      {durationValid && (
+        <>
+          <ProgressWrapper>
+            <Progress color={theme?.textColor} index={time} length={duration} />
+          </ProgressWrapper>
+          <Spacer8 />
+          <TimeWrapper>
+            <TimeLabel color={theme?.textColor}>{displayTime}</TimeLabel>
+            <TimeLabel color={theme?.textColor}>{displayLeft}</TimeLabel>
+          </TimeWrapper>
+          <Spacer16 />
+        </>
+      )}
 
       <Wrapper>
         <ControlsWrapper>
-          <IconButton
-            small
-            variant={variant}
-            Icon={Backward15}
-            onPress={onSkipBack}
-          />
-          <Spacer32 />
+          {durationValid && (
+            <>
+              <IconButton
+                small
+                variant={variant}
+                Icon={Backward15}
+                onPress={onSkipBack}
+              />
+              <Spacer32 />
+            </>
+          )}
           <PlayPauseButton
             variant={variant}
             Icon={playing ? Pause : Play}
             onPress={onTogglePlay}
           />
-          <Spacer32 />
-          <IconButton
-            small
-            variant={variant}
-            Icon={Forward15}
-            onPress={onSkipForward}
-          />
+          {durationValid && (
+            <>
+              <Spacer32 />
+              <IconButton
+                small
+                variant={variant}
+                Icon={Forward15}
+                onPress={onSkipForward}
+              />
+            </>
+          )}
+
           {subtitles !== undefined && onToggleSubtitles && (
             <SubtitlesWrapper>
               {subtitles ? (

--- a/client/src/lib/components/MediaControls/MediaControls.tsx
+++ b/client/src/lib/components/MediaControls/MediaControls.tsx
@@ -92,7 +92,8 @@ const MediaControls: React.FC<MediaControlsProps> = ({
 
   const variant = light ? 'secondary' : 'tertiary';
 
-  // Exoplayer in android have issues with sending correct duration for mp3
+  // Exoplayer in android have issues with sending correct duration for mp3. It is flaky but when
+  // it fails it sends -9223372036854775807 as duration. (lowest long value in Java +1)
   // https://github.com/google/ExoPlayer/issues/7314
   // A temporary fix is to not show erronius progress and disable skip buttons when
   // that happens.


### PR DESCRIPTION

| Working duration | Faulty duration |
|-|-|
|<img src="https://github.com/29ki/29k/assets/1139207/2f5f19e1-74e7-472c-b0c7-470e29353f3e" width="200" /> | <img src="https://github.com/29ki/29k/assets/1139207/df2f0a19-f1a3-4d88-a909-d815092de1ed" width="200" />|

Relates to this issue in ExoPlayer used in our Video library https://github.com/google/ExoPlayer/issues/7314

