### PR TITLE
Use session language when presenting its exercise

### DIFF
--- a/client/src/lib/components/Cards/SessionCard/CompletedSessionCard.tsx
+++ b/client/src/lib/components/Cards/SessionCard/CompletedSessionCard.tsx
@@ -40,10 +40,10 @@ const CompletedSessionCard: React.FC<CompletedSessionCardProps> = ({
 }) => {
   const {t} = useTranslation('Component.CompletedSessionCard');
   const {
-    payload: {mode, exerciseId},
+    payload: {mode, exerciseId, language},
     timestamp,
   } = completedSessionEvent;
-  const exercise = useExerciseById(exerciseId);
+  const exercise = useExerciseById(exerciseId, language);
   const hostProfile = useUserProfile(completedSessionEvent.payload.hostId);
   const {navigate} =
     useNavigation<

--- a/client/src/lib/components/Cards/SessionCard/SessionCard.tsx
+++ b/client/src/lib/components/Cards/SessionCard/SessionCard.tsx
@@ -89,8 +89,8 @@ const SessionCard: React.FC<SessionCardProps> = ({
   onBeforeContextPress,
   style,
 }) => {
-  const {exerciseId, startTime, hostProfile} = session;
-  const exercise = useExerciseById(exerciseId);
+  const {exerciseId, startTime, hostProfile, language} = session;
+  const exercise = useExerciseById(exerciseId, language);
   const user = useUser();
   const {navigate} =
     useNavigation<NativeStackNavigationProp<AppStackProps & ModalStackProps>>();

--- a/client/src/lib/content/hooks/useExerciseById.spec.ts
+++ b/client/src/lib/content/hooks/useExerciseById.spec.ts
@@ -24,6 +24,20 @@ describe('useExerciseById', () => {
     expect(result.current).toBe('some-exercise');
   });
 
+  it('returns a translated exercise for a specific language', () => {
+    const {result} = renderHook(() =>
+      useExerciseById('some-exercise-id', 'sv'),
+    );
+
+    expect(mockT).toHaveBeenCalledTimes(1);
+    expect(mockT).toHaveBeenCalledWith('some-exercise-id', {
+      returnObjects: true,
+      lng: 'sv',
+    });
+
+    expect(result.current).toBe('some-exercise');
+  });
+
   it('returns null when no ID is provided', () => {
     const {result} = renderHook(() => useExerciseById(undefined));
 

--- a/client/src/lib/content/hooks/useExerciseById.ts
+++ b/client/src/lib/content/hooks/useExerciseById.ts
@@ -1,13 +1,17 @@
 import {useMemo} from 'react';
 import {Exercise} from '../../../../../shared/src/types/generated/Exercise';
 import useGetExerciseById from './useGetExerciseById';
+import {LANGUAGE_TAG} from '../../i18n';
 
-const useExerciseById = (id: string | undefined): Exercise | null => {
+const useExerciseById = (
+  id: string | undefined,
+  language?: LANGUAGE_TAG,
+): Exercise | null => {
   const getExerciseById = useGetExerciseById();
 
   return useMemo(
-    () => (id ? getExerciseById(id) : null),
-    [getExerciseById, id],
+    () => (id ? getExerciseById(id, language) : null),
+    [getExerciseById, id, language],
   );
 };
 

--- a/client/src/lib/content/hooks/useGetExerciseById.spec.ts
+++ b/client/src/lib/content/hooks/useGetExerciseById.spec.ts
@@ -26,4 +26,18 @@ describe('useGetExerciseById', () => {
       returnObjects: true,
     });
   });
+
+  it('returns a translated exercise for a specific language', () => {
+    const {result} = renderHook(() => useGetExerciseById());
+
+    act(() => {
+      expect(result.current('some-exercise-id', 'sv')).toBe('some-exercise');
+    });
+
+    expect(mockT).toHaveBeenCalledTimes(1);
+    expect(mockT).toHaveBeenCalledWith('some-exercise-id', {
+      returnObjects: true,
+      lng: 'sv',
+    });
+  });
 });

--- a/client/src/lib/sessions/hooks/useSessionReminder.ts
+++ b/client/src/lib/sessions/hooks/useSessionReminder.ts
@@ -9,10 +9,10 @@ import useNotificationsState from '../../notifications/state/state';
 import {logEvent} from '../../metrics';
 
 const useSessionReminder = (session: LiveSessionType) => {
-  const {id, exerciseId, startTime, link} = session;
+  const {id, exerciseId, language, startTime, link} = session;
 
   const {t} = useTranslation('Notification.SessionReminder');
-  const exercise = useExerciseById(exerciseId);
+  const exercise = useExerciseById(exerciseId, language);
 
   const {setTriggerNotification, removeTriggerNotification} =
     useTriggerNotifications();

--- a/client/src/routes/modals/AssignNewHostModal/AssignNewHostModal.tsx
+++ b/client/src/routes/modals/AssignNewHostModal/AssignNewHostModal.tsx
@@ -39,7 +39,7 @@ const AssignNewHostModal = () => {
   const {t} = useTranslation('Modal.AssignNewHost');
   const user = useUser();
 
-  const exercise = useExerciseById(session?.exerciseId);
+  const exercise = useExerciseById(session?.exerciseId, session?.language);
   const confirmToggleReminder = useConfirmSessionReminder(session);
 
   const isHost = user?.uid === session.hostId;

--- a/client/src/routes/modals/CompletedSessionModal/CompletedSessionModal.tsx
+++ b/client/src/routes/modals/CompletedSessionModal/CompletedSessionModal.tsx
@@ -111,7 +111,7 @@ const CompletedSessionModal = () => {
   const {t} = useTranslation('Modal.CompletedSession');
   const {payload, timestamp} = completedSessionEvent;
   const user = useUser();
-  const exercise = useExerciseById(payload.exerciseId);
+  const exercise = useExerciseById(payload.exerciseId, payload.language);
   const tags = useGetTagsById(exercise?.tags);
   const {getSharingPostForSession} = useSharingPosts(exercise?.id);
   const getFeedbackBySessionId = useGetFeedbackBySessionId();

--- a/client/src/routes/modals/CreateSessionModal/components/steps/SetDateTimeStep.tsx
+++ b/client/src/routes/modals/CreateSessionModal/components/steps/SetDateTimeStep.tsx
@@ -60,8 +60,10 @@ const SetDateTimeStep: React.FC<StepProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [sessionDateTime, setSessionDateTime] = useState<dayjs.Dayjs>(dayjs());
 
+  const language = i18n.resolvedLanguage as LANGUAGE_TAG;
+
   const {addSession} = useSessions();
-  const exercise = useExerciseById(selectedExercise);
+  const exercise = useExerciseById(selectedExercise, language);
   const logSessionMetricEvent = useLogSessionMetricEvents();
 
   const onChange = useCallback(
@@ -76,7 +78,7 @@ const SetDateTimeStep: React.FC<StepProps> = ({
         exerciseId: selectedExercise,
         type: selectedModeAndType.type,
         startTime: sessionDateTime,
-        language: i18n.resolvedLanguage as LANGUAGE_TAG,
+        language: language,
       });
       setIsLoading(false);
       logSessionMetricEvent('Create Sharing Session', session);

--- a/client/src/routes/modals/EditSessionDateModal/EditSessionDateModal.tsx
+++ b/client/src/routes/modals/EditSessionDateModal/EditSessionDateModal.tsx
@@ -64,7 +64,7 @@ const EditSessionDateModal = () => {
   const navigation =
     useNavigation<NativeStackNavigationProp<AppStackProps & ModalStackProps>>();
 
-  const exercise = useExerciseById(session?.exerciseId);
+  const exercise = useExerciseById(session?.exerciseId, session?.language);
 
   const confirmToggleReminder = useConfirmSessionReminder(session);
 

--- a/client/src/routes/modals/HostSessionByInviteModal/HostSessionByInviteModal.tsx
+++ b/client/src/routes/modals/HostSessionByInviteModal/HostSessionByInviteModal.tsx
@@ -92,7 +92,7 @@ const InvitationModal: React.FC<{
   hostingCode: number;
   onError: (err: Error) => void;
 }> = ({session, hostingCode, onError}) => {
-  const exercise = useExerciseById(session?.exerciseId);
+  const exercise = useExerciseById(session?.exerciseId, session?.language);
   const tags = useGetSessionCardTags(exercise);
   const {t} = useTranslation('Modal.HostSessionByInvite');
   const {fetchSessions} = useSessions();

--- a/client/src/routes/modals/SessionModal/SessionModal.tsx
+++ b/client/src/routes/modals/SessionModal/SessionModal.tsx
@@ -128,7 +128,7 @@ const SessionModal = () => {
     useNavigation<NativeStackNavigationProp<AppStackProps & ModalStackProps>>();
 
   const addToCalendar = useAddSessionToCalendar();
-  const exercise = useExerciseById(session?.exerciseId);
+  const exercise = useExerciseById(session.exerciseId, session.language);
   const tags = useGetSessionCardTags(exercise);
   const {reminderEnabled, toggleReminder} = useSessionReminder(session);
   const confirmToggleReminder = useConfirmSessionReminder(session);

--- a/client/src/routes/screens/Journey/components/JourneyNode.tsx
+++ b/client/src/routes/screens/Journey/components/JourneyNode.tsx
@@ -124,12 +124,12 @@ const JourneyNode: React.FC<JourneyNodeProps> = ({
   isLast = false,
 }) => {
   const {
-    payload: {id, mode, exerciseId, hostId, type},
+    payload: {id, mode, exerciseId, hostId, type, language},
     timestamp,
     sharingPost,
   } = completedSessionEvent;
   const {t} = useTranslation('Component.MyPostCard');
-  const exercise = useExerciseById(exerciseId);
+  const exercise = useExerciseById(exerciseId, language);
   const hostProfile = useUserProfile(hostId);
   const user = useUser();
   const getFeedbackBySessionId = useGetFeedbackBySessionId();


### PR DESCRIPTION
[Task in notion](https://www.notion.so/29k/Aware-app-e8b9a3d421cc499f94d0cc1a0f7f51d4?pvs=4#53d396f927a341b3a3a7dce501f6a8c1)

This makes sure that session exercises are listed and completed in the session's language. Examples:
| Home | Journey | Completed | Filtered |
|--------|--------|--------|--------|
| ![image](https://github.com/29ki/29k/assets/474066/8857c6e6-6ea0-4fab-a300-e66d4af120c5) | ![image](https://github.com/29ki/29k/assets/474066/036cc155-fb1d-4de2-b553-96fd70264733) | ![image](https://github.com/29ki/29k/assets/474066/9806bd10-8b15-4c90-a947-dd637e836b13) | ![image](https://github.com/29ki/29k/assets/474066/e6ca9cb9-1b95-4621-8cbe-006a47318b54) | 