### PR TITLE
Gracefully force language from link

### DIFF
--- a/client/__mocks__/@react-navigation/native.js
+++ b/client/__mocks__/@react-navigation/native.js
@@ -1,6 +1,8 @@
 const mockNavigation = {
   navigate: jest.fn(),
   popToTop: jest.fn(),
+  addListener: jest.fn(),
+  getCurrentRoute: jest.fn(),
 };
 
 export const DefaultTheme = {

--- a/client/__mocks__/react-native-localize.js
+++ b/client/__mocks__/react-native-localize.js
@@ -1,1 +1,1 @@
-export const findBestAvailableLanguage = () => ({languageTag: 'en'});
+export const findBestAvailableLanguage = jest.fn(() => ({languageTag: 'en'}));

--- a/client/src/Bootstrap.tsx
+++ b/client/src/Bootstrap.tsx
@@ -18,6 +18,7 @@ import usePreferredLanguage from './lib/i18n/hooks/usePreferredLanguage';
 import {LANGUAGE_TAG} from './lib/i18n';
 import useNotificationsSetup from './lib/notifications/hooks/useNotificationsSetup';
 import useUpdatePracticeReminders from './lib/reminders/hooks/useUpdatePracticeReminders';
+import useLanguageFromRoute from './lib/i18n/hooks/useLanguageFromRoute';
 
 i18nLib.init();
 sentry.init();
@@ -36,6 +37,7 @@ const useInitHidableContent = () => {
 const Bootstrap: React.FC<{children: React.ReactNode}> = ({children}) => {
   useAuthenticateUser();
   usePreferredLanguage();
+  useLanguageFromRoute();
   useNotificationsSetup();
 
   const {i18n} = useTranslation();

--- a/client/src/lib/i18n/hooks/useLanguageFromRoute.spec.ts
+++ b/client/src/lib/i18n/hooks/useLanguageFromRoute.spec.ts
@@ -1,0 +1,73 @@
+import {renderHook} from '@testing-library/react-hooks';
+import useAppState from '../../appState/state/state';
+import useLanguageFromRoute from './useLanguageFromRoute';
+import {useNavigation} from '@react-navigation/native';
+import {findBestAvailableLanguage} from 'react-native-localize';
+
+const mockI18n = {
+  changeLanguage: jest.fn(),
+};
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({i18n: mockI18n}),
+}));
+
+const mockNavigation = (useNavigation as jest.Mock)();
+const mockAddListener = mockNavigation.addListener as jest.Mock;
+const mockGetCurrentRoute = mockNavigation.getCurrentRoute as jest.Mock;
+
+mockAddListener.mockImplementation((event: string, callback: () => {}) => {
+  callback();
+});
+
+const mockFindBestAvailableLanguage = findBestAvailableLanguage as jest.Mock;
+
+mockFindBestAvailableLanguage.mockImplementation(
+  (languageTags: readonly string[]) => ({
+    languageTag: languageTags[0],
+  }),
+);
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useLanguageFromRoute', () => {
+  it('listens for language in route params', () => {
+    mockGetCurrentRoute.mockReturnValueOnce({
+      params: {language: 'sv'},
+    });
+
+    renderHook(() => useLanguageFromRoute());
+
+    expect(mockAddListener).toHaveBeenCalledTimes(1);
+    expect(mockAddListener).toHaveBeenCalledWith('state', expect.any(Function));
+
+    expect(mockGetCurrentRoute).toHaveBeenCalledTimes(1);
+
+    expect(mockFindBestAvailableLanguage).toHaveBeenCalledTimes(1);
+    expect(mockFindBestAvailableLanguage).toHaveBeenCalledWith(['sv']);
+
+    expect(useAppState.getState().settings.preferredLanguage).toEqual('sv');
+  });
+
+  it('supports a comma separated list of languages', () => {
+    mockGetCurrentRoute.mockReturnValueOnce({
+      params: {language: 'pt,sv'},
+    });
+
+    renderHook(() => useLanguageFromRoute());
+
+    expect(mockFindBestAvailableLanguage).toHaveBeenCalledTimes(1);
+    expect(mockFindBestAvailableLanguage).toHaveBeenCalledWith(['pt', 'sv']);
+
+    expect(useAppState.getState().settings.preferredLanguage).toEqual('pt');
+  });
+
+  it('does nothing if language param is not set', () => {
+    mockGetCurrentRoute.mockReturnValueOnce({});
+
+    renderHook(() => useLanguageFromRoute());
+
+    expect(mockFindBestAvailableLanguage).toHaveBeenCalledTimes(0);
+  });
+});

--- a/client/src/lib/i18n/hooks/useLanguageFromRoute.ts
+++ b/client/src/lib/i18n/hooks/useLanguageFromRoute.ts
@@ -1,0 +1,34 @@
+import {useEffect} from 'react';
+import {useTranslation} from 'react-i18next';
+import {useNavigation} from '@react-navigation/native';
+import {findBestAvailableLanguage} from 'react-native-localize';
+import {LANGUAGE_TAG} from '../../../../../shared/src/constants/i18n';
+import useAppState from '../../appState/state/state';
+
+const useLanguageFromRoute = () => {
+  const {i18n} = useTranslation();
+  const navigation = useNavigation();
+  const setSettings = useAppState(state => state.setSettings);
+
+  useEffect(
+    () =>
+      navigation.addListener('state', () => {
+        // NOTE: This method is not typed correctly but is available and takes care of parsing the router state correctly
+        const route = (navigation as any).getCurrentRoute();
+        if (route && route?.params?.language) {
+          // Figure what language to use from the route params
+          const languages = route.params.language.split(',');
+          const languageTag = findBestAvailableLanguage(languages)
+            ?.languageTag as LANGUAGE_TAG;
+
+          if (languageTag) {
+            // Set the route language as the preferred language
+            setSettings({preferredLanguage: languageTag});
+          }
+        }
+      }),
+    [navigation, i18n, setSettings],
+  );
+};
+
+export default useLanguageFromRoute;


### PR DESCRIPTION
[Task in notion](https://www.notion.so/29k/Aware-app-e8b9a3d421cc499f94d0cc1a0f7f51d4?pvs=4#bd45e339b0734f5fb8d8e5dfb1b58f4c)

This allows deep links to gracefully set what language the app should have. E.g:
```
https://29k.org/collections/68172f5c-955a-43e0-9cef-ae3bc77c9593?language=sv
```
If the user supports Swedish the link will set the preferred language to that - even if Swedish is a low supported language