### PR TITLE
Revert "Bump decap-cms-app from 3.4.0 to 3.6.2 in /cms"

### DIFF
--- a/cms/package.json
+++ b/cms/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "dayjs": "^1.11.13",
-    "decap-cms-app": "3.6.2",
+    "decap-cms-app": "3.4.0",
     "decap-cms-media-library-cloudinary": "^3.0.3",
     "i18next": "^24.2.2",
     "react-native-safe-area-context": "^5.2.0",

--- a/cms/yarn.lock
+++ b/cms/yarn.lock
@@ -2624,11 +2624,6 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@vercel/stega@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@vercel/stega/-/stega-0.1.2.tgz#0c20c5c9419c4288b1de58a64b5f9f26c763b25f"
-  integrity sha512-P7mafQXjkrsoyTRppnt0N21udKS9wUmLXHRyP9saLXLHw32j/FgUJ3FscSWgvSqRs4cj7wKZtwqJEvWJ2jbGmA==
-
 "@vitejs/plugin-react@^4.3.4":
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-4.3.4.tgz#c64be10b54c4640135a5b28a2432330e88ad7c20"
@@ -3902,10 +3897,10 @@ decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
-decap-cms-app@3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/decap-cms-app/-/decap-cms-app-3.6.2.tgz#f3ea5be156a584eb85fb9af189e32fe1f02ff9a8"
-  integrity sha512-VuOXhU2zpwVy7ZZJSjagEElmZUnKT0BGHXk4dC+wEgIGT7Mvf0P4r9kQ0nus/3AAWDfRPfJ9EHZdNZlTBspjOw==
+decap-cms-app@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/decap-cms-app/-/decap-cms-app-3.4.0.tgz#1d6167ed09bf5f2330bd95498d211e848f92cc2c"
+  integrity sha512-qiR6fQw7VcnnCw1v4gYjSUVxqWVydu9UcmAJGttgd3vDxKl7POoXOORrVMe1kZ+jUq+G95f/SYATng+++1Nh1w==
   dependencies:
     "@emotion/react" "^11.11.1"
     "@emotion/styled" "^11.11.0"
@@ -3915,17 +3910,16 @@ decap-cms-app@3.6.2:
     decap-cms-backend-azure "^3.1.3"
     decap-cms-backend-bitbucket "^3.1.4"
     decap-cms-backend-git-gateway "^3.2.2"
-    decap-cms-backend-gitea "^3.1.5"
     decap-cms-backend-github "^3.2.2"
     decap-cms-backend-gitlab "^3.2.2"
     decap-cms-backend-proxy "^3.1.4"
     decap-cms-backend-test "^3.1.3"
-    decap-cms-core "^3.6.1"
+    decap-cms-core "^3.5.0"
     decap-cms-editor-component-image "^3.1.3"
     decap-cms-lib-auth "^3.0.5"
-    decap-cms-lib-util "^3.2.0"
+    decap-cms-lib-util "^3.1.0"
     decap-cms-lib-widgets "^3.1.0"
-    decap-cms-locales "^3.3.0"
+    decap-cms-locales "^3.2.0"
     decap-cms-ui-default "^3.1.4"
     decap-cms-widget-boolean "^3.1.3"
     decap-cms-widget-code "^3.1.4"
@@ -3933,11 +3927,11 @@ decap-cms-app@3.6.2:
     decap-cms-widget-datetime "^3.2.3"
     decap-cms-widget-file "^3.1.3"
     decap-cms-widget-image "^3.1.3"
-    decap-cms-widget-list "^3.3.0"
+    decap-cms-widget-list "^3.2.2"
     decap-cms-widget-map "^3.1.4"
-    decap-cms-widget-markdown "^3.3.0"
+    decap-cms-widget-markdown "^3.2.0"
     decap-cms-widget-number "^3.1.3"
-    decap-cms-widget-object "^3.3.1"
+    decap-cms-widget-object "^3.1.4"
     decap-cms-widget-relation "^3.3.2"
     decap-cms-widget-select "^3.2.2"
     decap-cms-widget-string "^3.1.3"
@@ -3991,14 +3985,6 @@ decap-cms-backend-git-gateway@^3.2.2:
     jwt-decode "^3.0.0"
     minimatch "^3.0.4"
 
-decap-cms-backend-gitea@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/decap-cms-backend-gitea/-/decap-cms-backend-gitea-3.1.5.tgz#cb6d28ce029e9e9bf591fb181258d6d36803a333"
-  integrity sha512-kmmNFex2YjNyHMgRKdBa3DDLgODH016IKR6wP2dKqSg/m9Xos8nE5KyJPw8E8zrZUa1+j1V2YpPNx/1b1dJ42w==
-  dependencies:
-    js-base64 "^3.0.0"
-    semaphore "^1.1.0"
-
 decap-cms-backend-github@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/decap-cms-backend-github/-/decap-cms-backend-github-3.2.2.tgz#e781a1236f3d266b7235850e0be3991e9fe4a943"
@@ -4036,14 +4022,13 @@ decap-cms-backend-test@^3.1.3:
   resolved "https://registry.yarnpkg.com/decap-cms-backend-test/-/decap-cms-backend-test-3.1.3.tgz#093da1cada4ae81872d385a69eb9b530f5f38892"
   integrity sha512-SsUzvljOnQYFqbFKshajKSPlzY8O8xzE0nWI4GqUAugXx5mxD1lNov0WgtO/5UPXr2zNEtxyQzF+gz6A4XhHrA==
 
-decap-cms-core@^3.6.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/decap-cms-core/-/decap-cms-core-3.6.1.tgz#f85fcb7070a3d7c93009ba0f8b5154d2c895a666"
-  integrity sha512-qIvkdHfDR2VTOpIEOxdtY43Ac2MqfgMSkHpRYq+x+LQ/HBS9p5j24S075FROKGJj9j/BfCJ2/Nd7ETmMmnvVRw==
+decap-cms-core@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/decap-cms-core/-/decap-cms-core-3.5.0.tgz#f582203d0dd08ea422c0afd3ed4da7e497bbfab6"
+  integrity sha512-+R73V6Q8IELrsSeOav+B/FjG+v1Z/8h8lLIX12hYHOTBqtsKB4bH2pln/lTfAyVmeIlMjETR+6KOrayM4kqiww==
   dependencies:
     "@iarna/toml" "2.2.5"
     "@reduxjs/toolkit" "^1.9.1"
-    "@vercel/stega" "^0.1.2"
     ajv "8.12.0"
     ajv-errors "^3.0.0"
     ajv-keywords "^5.0.0"
@@ -4103,10 +4088,10 @@ decap-cms-lib-auth@^3.0.5:
   resolved "https://registry.yarnpkg.com/decap-cms-lib-auth/-/decap-cms-lib-auth-3.0.5.tgz#61bd78baa0c677f0803f9fc8a65c9bfcb01e07f9"
   integrity sha512-NG+dI1Pg0UBoxRQfuI0zeRLZAtPU23R3qUOA1mDUJ4OpKmX6/lsznmvu0l+e3TzGUhCkOXyz2fl/9HctsMjTXw==
 
-decap-cms-lib-util@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/decap-cms-lib-util/-/decap-cms-lib-util-3.2.0.tgz#6450d8292be5deac9cbc2123cf5f3ca9724e933e"
-  integrity sha512-kNsR6hkbVVdcKy08IlHsm2h4TGac2mepLVysPCuqP/F7nAyNjZenqHUuXSgiUaq2Nph0Xa+8PfXCHMK4Ti+91A==
+decap-cms-lib-util@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/decap-cms-lib-util/-/decap-cms-lib-util-3.1.0.tgz#6cc7a2d9d7ef1d9a7a11886284d7aac513159400"
+  integrity sha512-lrEwLDN46x2Jiu+bCN70P9vhd/5nvP9tL793ovJiI06SylrM0wVfVZPQGgRH/p8bDJBenaxgFwaA2E7mH7u3sQ==
   dependencies:
     js-sha256 "^0.9.0"
     localforage "^1.7.3"
@@ -4119,10 +4104,10 @@ decap-cms-lib-widgets@^3.1.0:
   dependencies:
     dayjs "^1.11.10"
 
-decap-cms-locales@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/decap-cms-locales/-/decap-cms-locales-3.3.0.tgz#1d08699332915c879477908b485df00f024cd8a4"
-  integrity sha512-4DOB2zGoCkKZsS/VpfvgoZDUA+D0tBI6AOS7WMaUvndBBJ47+5V/4YAeGpMKMLZ1oa6JnKa8OiakgM/QelVFPg==
+decap-cms-locales@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/decap-cms-locales/-/decap-cms-locales-3.2.0.tgz#fd0a73afcb11094bd6c515f3194517b134b33eaa"
+  integrity sha512-En/jFGRK0noXVGVuZk+pTl51v1mJAO4rBK3R3BuTxR/X83Pq66C3KPtRpv/qPvNfC23Y5LztPXDYai2x8DST5A==
 
 decap-cms-media-library-cloudinary@^3.0.3:
   version "3.0.3"
@@ -4181,10 +4166,10 @@ decap-cms-widget-image@^3.1.3:
   resolved "https://registry.yarnpkg.com/decap-cms-widget-image/-/decap-cms-widget-image-3.1.3.tgz#22dbf32ca74fc713a531f8f6645e3c5a17b04860"
   integrity sha512-5wIIWP7OwbuWRljVV4XDcl3hx19Lp6KyQDZ1frlXfZXxgwu2xeOOw/D/ri2Nb5zIGZjG9DUp7bgBYBF92dXy5A==
 
-decap-cms-widget-list@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/decap-cms-widget-list/-/decap-cms-widget-list-3.3.0.tgz#0bb7546078e7aa8aa40faf94f1881a2674d7b9ab"
-  integrity sha512-Lno4B/XqQuexIrJWwn9qOCTpqWcvcQCNE61sGejVlWmMwYpnR18A9dUq/c4TnP5gyPNObhK8dfJvxcuCdHqBQQ==
+decap-cms-widget-list@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/decap-cms-widget-list/-/decap-cms-widget-list-3.2.2.tgz#0571024f65bcb09cbe112f4b12b126e2e8a3c7b6"
+  integrity sha512-tMb8K6aJh0vjTKbkhk8HYJfV6fkJkuUYhtLRWiPP2hhAmta+TZ8oI1Ue0bRBM7+G5WfWMB82wGLGm0psnwSkRA==
   dependencies:
     "@dnd-kit/core" "^6.0.8"
     "@dnd-kit/modifiers" "^6.0.1"
@@ -4197,10 +4182,10 @@ decap-cms-widget-map@^3.1.4:
   dependencies:
     ol "^6.9.0"
 
-decap-cms-widget-markdown@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/decap-cms-widget-markdown/-/decap-cms-widget-markdown-3.3.0.tgz#95db139552fa98bd26ac44b3a16b7ce926689132"
-  integrity sha512-ea/lMzOv66hiQMmruj7nWY0kJer4rrUEOxnVk1tIYzI7IYVXRqtPjS1wipLQJnk3PeGZXviPHUUPR0pmRumMXQ==
+decap-cms-widget-markdown@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/decap-cms-widget-markdown/-/decap-cms-widget-markdown-3.2.0.tgz#900794dad3af289b94eb2791b03a5bf32ad06ac0"
+  integrity sha512-8na7JrD80pUjbn8NVDZMw70dl3TXpZIuLj1EQkwU5kwvBRGE5Fth2PcON+kL7uyhV6A270nZEXUKfy1ucqpUuw==
   dependencies:
     dompurify "^2.2.6"
     is-hotkey "^0.2.0"
@@ -4230,10 +4215,10 @@ decap-cms-widget-number@^3.1.3:
   resolved "https://registry.yarnpkg.com/decap-cms-widget-number/-/decap-cms-widget-number-3.1.3.tgz#f859de3fa349df87b67055e1d01718162155c1bc"
   integrity sha512-fcncjNvAjfIYDg/jnUVQSre3jwb9JTaylPRiTMZa41zhwQVvH2XL98lzkPyPQU6nXGPnlN7p/hV8wNqbklm/wg==
 
-decap-cms-widget-object@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/decap-cms-widget-object/-/decap-cms-widget-object-3.3.1.tgz#fa45f535c37e48caa628e2cf6d3ede1f28355808"
-  integrity sha512-xqfXYf4ktcqBkKyzzCFkE8knjybvygVm3QwIxfRICHllDNhznFL1PnXhbysEiyKHtIUswyicNW8fVljuR/Fm0g==
+decap-cms-widget-object@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/decap-cms-widget-object/-/decap-cms-widget-object-3.1.4.tgz#0873e41947f25dd6ae2001c9b8e448b8778e2802"
+  integrity sha512-7nckihnmU4UNzwmX+H9+xYrlX9tZmvPLAqBQzLmkoMUcz0eMRwZ3vcvH0AfUYVawtiw4C5AxnuBh2yg4zc2guQ==
 
 decap-cms-widget-relation@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
Reverts 29ki/29k#6682 until https://github.com/decaporg/decap-cms/pull/7394 is fixed